### PR TITLE
When calling the Taxjar client DeleteOrder or DeleteRefund API routin…

### DIFF
--- a/src/Taxjar.Tests/TaxJar.Tests.csproj
+++ b/src/Taxjar.Tests/TaxJar.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -73,14 +73,11 @@
     <Compile Include="Client.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\taxjar-c#\TaxJar\TaxJar\TaxJar.csproj">
+    <ProjectReference Include="..\TaxJar\TaxJar.csproj">
       <Project>{CE4FFA2A-801C-488A-BF28-0EAAB8877C2D}</Project>
       <Name>TaxJar</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Fixtures\" />
-    <Folder Include="Infrastructure\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/Taxjar/Entities/TaxjarOrder.cs
+++ b/src/Taxjar/Entities/TaxjarOrder.cs
@@ -4,69 +4,69 @@ using Newtonsoft.Json;
 
 namespace Taxjar
 {
-	public class OrdersRequest
-	{
-		[JsonProperty("orders")]
-		public List<String> Orders { get; set; }
-	}
+    public class OrdersRequest
+    {
+        [JsonProperty("orders")]
+        public List<String> Orders { get; set; }
+    }
 
-	public class OrderRequest
-	{
-		[JsonProperty("order")]
-		public Order Order { get; set; }
-	}
+    public class OrderRequest
+    {
+        [JsonProperty("order")]
+        public Order Order { get; set; }
+    }
 
-	public class Order
-	{
-		[JsonProperty("transaction_id")]
-		public string TransactionId { get; set; }
+    public class Order
+    {
+        [JsonProperty("transaction_id")]
+        public string TransactionId { get; set; }
 
-		[JsonProperty("user_id")]
-		public int UserId { get; set; }
+        [JsonProperty("user_id")]
+        public int UserId { get; set; }
 
-		[JsonProperty("transaction_date")]
-		public string TransactionDate { get; set; }
+        [JsonProperty("transaction_date")]
+        public string TransactionDate { get; set; }
 
-		[JsonProperty("from_country")]
-		public string FromCountry { get; set; }
+        [JsonProperty("from_country")]
+        public string FromCountry { get; set; }
 
-		[JsonProperty("from_zip")]
-		public string FromZip { get; set; }
+        [JsonProperty("from_zip")]
+        public string FromZip { get; set; }
 
-		[JsonProperty("from_state")]
-		public string FromState { get; set; }
+        [JsonProperty("from_state")]
+        public string FromState { get; set; }
 
-		[JsonProperty("from_city")]
-		public string FromCity { get; set; }
+        [JsonProperty("from_city")]
+        public string FromCity { get; set; }
 
-		[JsonProperty("from_street")]
-		public string FromStreet { get; set; }
+        [JsonProperty("from_street")]
+        public string FromStreet { get; set; }
 
-		[JsonProperty("to_country")]
-		public string ToCountry { get; set; }
+        [JsonProperty("to_country")]
+        public string ToCountry { get; set; }
 
-		[JsonProperty("to_zip")]
-		public string ToZip { get; set; }
+        [JsonProperty("to_zip")]
+        public string ToZip { get; set; }
 
-		[JsonProperty("to_state")]
-		public string ToState { get; set; }
+        [JsonProperty("to_state")]
+        public string ToState { get; set; }
 
-		[JsonProperty("to_city")]
-		public string ToCity { get; set; }
+        [JsonProperty("to_city")]
+        public string ToCity { get; set; }
 
-		[JsonProperty("to_street")]
-		public string ToStreet { get; set; }
+        [JsonProperty("to_street")]
+        public string ToStreet { get; set; }
 
-		[JsonProperty("amount")]
-		public decimal Amount { get; set; }
+        [JsonProperty("amount", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal Amount { get; set; }
 
-		[JsonProperty("shipping")]
-		public decimal Shipping { get; set; }
+        [JsonProperty("shipping", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal Shipping { get; set; }
 
-		[JsonProperty("sales_tax")]
-		public decimal SalesTax { get; set; }
+        [JsonProperty("sales_tax", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal SalesTax { get; set; }
 
-		[JsonProperty("line_items")]
-		public List<LineItem> LineItems { get; set; }
-	}
+        [JsonProperty("line_items")]
+        public List<LineItem> LineItems { get; set; }
+    }
 }

--- a/src/Taxjar/Entities/TaxjarRefund.cs
+++ b/src/Taxjar/Entities/TaxjarRefund.cs
@@ -4,72 +4,72 @@ using Newtonsoft.Json;
 
 namespace Taxjar
 {
-	public class RefundsRequest
-	{
-		[JsonProperty("refunds")]
-		public List<String> Refunds { get; set; }
-	}
+    public class RefundsRequest
+    {
+        [JsonProperty("refunds")]
+        public List<String> Refunds { get; set; }
+    }
 
-	public class RefundRequest
-	{
-		[JsonProperty("refund")]
-		public Refund Refund { get; set; }
-	}
+    public class RefundRequest
+    {
+        [JsonProperty("refund")]
+        public Refund Refund { get; set; }
+    }
 
-	public class Refund
-	{
-		[JsonProperty("transaction_id")]
-		public string TransactionId { get; set; }
+    public class Refund
+    {
+        [JsonProperty("transaction_id")]
+        public string TransactionId { get; set; }
 
-		[JsonProperty("user_id")]
-		public int UserId { get; set; }
+        [JsonProperty("user_id")]
+        public int UserId { get; set; }
 
-		[JsonProperty("transaction_date")]
-		public string TransactionDate { get; set; }
+        [JsonProperty("transaction_date")]
+        public string TransactionDate { get; set; }
 
-		[JsonProperty("transaction_reference_id")]
-		public string TransactionReferenceId { get; set; }
+        [JsonProperty("transaction_reference_id")]
+        public string TransactionReferenceId { get; set; }
 
-		[JsonProperty("from_country")]
-		public string FromCountry { get; set; }
+        [JsonProperty("from_country")]
+        public string FromCountry { get; set; }
 
-		[JsonProperty("from_zip")]
-		public string FromZip { get; set; }
+        [JsonProperty("from_zip")]
+        public string FromZip { get; set; }
 
-		[JsonProperty("from_state")]
-		public string FromState { get; set; }
+        [JsonProperty("from_state")]
+        public string FromState { get; set; }
 
-		[JsonProperty("from_city")]
-		public string FromCity { get; set; }
+        [JsonProperty("from_city")]
+        public string FromCity { get; set; }
 
-		[JsonProperty("from_street")]
-		public string FromStreet { get; set; }
+        [JsonProperty("from_street")]
+        public string FromStreet { get; set; }
 
-		[JsonProperty("to_country")]
-		public string ToCountry { get; set; }
+        [JsonProperty("to_country")]
+        public string ToCountry { get; set; }
 
-		[JsonProperty("to_zip")]
-		public string ToZip { get; set; }
+        [JsonProperty("to_zip")]
+        public string ToZip { get; set; }
 
-		[JsonProperty("to_state")]
-		public string ToState { get; set; }
+        [JsonProperty("to_state")]
+        public string ToState { get; set; }
 
-		[JsonProperty("to_city")]
-		public string ToCity { get; set; }
+        [JsonProperty("to_city")]
+        public string ToCity { get; set; }
 
-		[JsonProperty("to_street")]
-		public string ToStreet { get; set; }
+        [JsonProperty("to_street")]
+        public string ToStreet { get; set; }
 
-		[JsonProperty("amount")]
-		public decimal Amount { get; set; }
+        [JsonProperty("amount", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal Amount { get; set; }
 
-		[JsonProperty("shipping")]
-		public decimal Shipping { get; set; }
+        [JsonProperty("shipping", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal Shipping { get; set; }
 
-		[JsonProperty("sales_tax")]
-		public decimal SalesTax { get; set; }
+        [JsonProperty("sales_tax", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal SalesTax { get; set; }
 
-		[JsonProperty("line_items")]
-		public List<LineItem> LineItems { get; set; }
-	}
+        [JsonProperty("line_items")]
+        public List<LineItem> LineItems { get; set; }
+    }
 }

--- a/src/Taxjar/Taxjar.csproj
+++ b/src/Taxjar/Taxjar.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -29,14 +29,14 @@
     <ConsolePause>false</ConsolePause>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="RestSharp">
       <HintPath>..\packages\RestSharp.105.2.3\lib\net45\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>..\..\..\taxjar-c#-shared\TaxJarShared\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -58,8 +58,5 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Entities\" />
-    <Folder Include="Infrastructure\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>


### PR DESCRIPTION
…es, the JsonConvert.DeserializeObject routine was throwing an exception for decimal fields since the Taxjar service is not returning these fields in the response.  The changes to the Taxjar.Order and Taxjar.Refund classes fixes this issue.  The changes made to the csproj files were needed to get the solution to compile.  All tests were ran and passed.  I also have tests in my client's code which test that these changes work from an integration test prospective.