### PR TITLE
Throw errors buried by RestSharp

### DIFF
--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -125,6 +125,11 @@ namespace Taxjar
                 throw new TaxjarException(res.StatusCode, taxjarError, errorMessage);                
             }
 
+            if(res.ResponseStatus != ResponseStatus.Completed)
+            {
+                throw new Exception(res.ErrorMessage, res.ErrorException);
+            }
+
             return res.Content;
         }
 


### PR DESCRIPTION
We've noticed that we're getting a few empty responses from the TaxJar client that we believe are caused by some kind of underlying network issue.  However, the exact nature of the problem is lost when the response is returned from the RestSharp client.  Digging into that code, it seems that if an exception is caught, it's returned without a "faulty" response code, and thus is completely ignored by the TaxJar client,
However, the Response Status _is_ set, and can be used to diagnose an issue that doesn't fall within the expected range.
The addition of this check and subsequent re-throwing of the exception _should_ help diagnose problems with connectivity issues - though there is admittedly some potential to cause issues with calling code that is not expecting anything other than a TaxJarException to be thrown.