### PR TITLE
Tax Jurisdiction Names

### DIFF
--- a/src/Taxjar.Tests/Fixtures/taxes.json
+++ b/src/Taxjar.Tests/Fixtures/taxes.json
@@ -8,6 +8,12 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "US",
+      "state": "NJ",
+      "county": "BERGEN",
+      "city": "RAMSEY"
+    },
     "breakdown": {
       "taxable_amount": 16.5,
       "tax_collectable": 1.16,

--- a/src/Taxjar.Tests/Fixtures/taxes_canada.json
+++ b/src/Taxjar.Tests/Fixtures/taxes_canada.json
@@ -8,6 +8,10 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "CA",
+      "state": "ON"
+    },
     "breakdown": {
       "taxable_amount": 26.95,
       "tax_collectable": 3.5,

--- a/src/Taxjar.Tests/Fixtures/taxes_international.json
+++ b/src/Taxjar.Tests/Fixtures/taxes_international.json
@@ -8,6 +8,9 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "jurisdictions": {
+      "country": "FI"
+    },
     "breakdown": {
       "taxable_amount": 26.95,
       "tax_collectable": 6.47,

--- a/src/Taxjar.Tests/Taxes.cs
+++ b/src/Taxjar.Tests/Taxes.cs
@@ -58,8 +58,14 @@ namespace Taxjar.Tests
 			Assert.AreEqual(true, rates.FreightTaxable);
 			Assert.AreEqual("destination", rates.TaxSource);
 
-			// Breakdowns
-			Assert.AreEqual(1.5, rates.Breakdown.Shipping.TaxableAmount);
+            // Jurisdictions
+            Assert.AreEqual("US", rates.Jurisdictions.Country);
+            Assert.AreEqual("NJ", rates.Jurisdictions.State);
+            Assert.AreEqual("BERGEN", rates.Jurisdictions.County);
+            Assert.AreEqual("RAMSEY", rates.Jurisdictions.City);
+
+            // Breakdowns
+            Assert.AreEqual(1.5, rates.Breakdown.Shipping.TaxableAmount);
 			Assert.AreEqual(0.11, rates.Breakdown.Shipping.TaxCollectable);
 			Assert.AreEqual(0.07, rates.Breakdown.Shipping.CombinedTaxRate);
 			Assert.AreEqual(1.5, rates.Breakdown.Shipping.StateTaxableAmount);
@@ -148,8 +154,11 @@ namespace Taxjar.Tests
 			Assert.AreEqual(true, rates.FreightTaxable);
 			Assert.AreEqual("destination", rates.TaxSource);
 
-			// Breakdowns
-			Assert.AreEqual(26.95, rates.Breakdown.TaxableAmount);
+            // Jurisdictions
+            Assert.AreEqual("FI", rates.Jurisdictions.Country);
+
+            // Breakdowns
+            Assert.AreEqual(26.95, rates.Breakdown.TaxableAmount);
 			Assert.AreEqual(6.47, rates.Breakdown.TaxCollectable);
 			Assert.AreEqual(0.24, rates.Breakdown.CombinedTaxRate);
 			Assert.AreEqual(26.95, rates.Breakdown.CountryTaxableAmount);
@@ -215,8 +224,12 @@ namespace Taxjar.Tests
 			Assert.AreEqual(true, rates.FreightTaxable);
 			Assert.AreEqual("destination", rates.TaxSource);
 
-			// Breakdowns
-			Assert.AreEqual(26.95, rates.Breakdown.TaxableAmount);
+            // Jurisdictions
+            Assert.AreEqual("CA", rates.Jurisdictions.Country);
+            Assert.AreEqual("ON", rates.Jurisdictions.State);
+
+            // Breakdowns
+            Assert.AreEqual(26.95, rates.Breakdown.TaxableAmount);
 			Assert.AreEqual(3.5, rates.Breakdown.TaxCollectable);
 			Assert.AreEqual(0.13, rates.Breakdown.CombinedTaxRate);
 			Assert.AreEqual(26.95, rates.Breakdown.GSTTaxableAmount);

--- a/src/Taxjar/Entities/TaxjarTax.cs
+++ b/src/Taxjar/Entities/TaxjarTax.cs
@@ -35,6 +35,9 @@ namespace Taxjar
 		[JsonProperty("tax_source")]
 		public string TaxSource { get; set; }
 
+        [JsonProperty("jurisdictions")]
+        public TaxJurisdictions Jurisdictions { get; set; }
+
 		[JsonProperty("breakdown")]
 		public TaxBreakdown Breakdown { get; set; }
 	}

--- a/src/Taxjar/Entities/TaxjarTaxJurisdictions.cs
+++ b/src/Taxjar/Entities/TaxjarTaxJurisdictions.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Taxjar
+{
+    public class TaxJurisdictions
+    {
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("state")]
+        public string State { get; set; }
+
+        [JsonProperty("county")]
+        public string County { get; set; }
+
+        [JsonProperty("city")]
+        public string City { get; set; }
+    }
+}


### PR DESCRIPTION
This PR provides access to the new `jurisdictions` object in the /v2/taxes response.