### PR TITLE
Throw Buried Errors from RestSharp & Custom Timeouts

### DIFF
--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -125,6 +125,11 @@ namespace Taxjar
                 throw new TaxjarException(res.StatusCode, taxjarError, errorMessage);                
             }
 
+            if (res.ErrorException != null)
+            {
+                throw new Exception(res.ErrorMessage, res.ErrorException);
+            }
+
             return res.Content;
         }
 

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -21,12 +21,14 @@ namespace Taxjar
         public string apiKey { get; set; }
         public string apiUrl { get; set; }
         public IDictionary<string, string> headers { get; set; }
+        public int timeout { get; set; }
 
         public TaxjarApi(string apiKey, object parameters = null)
         {
             this.apiKey = apiKey;
             this.apiUrl = TaxjarConstants.DefaultApiUrl + "/" + TaxjarConstants.ApiVersion + "/";
             this.headers = new Dictionary<string, string>();
+            this.timeout = 0; // Seconds
 
             if (parameters != null)
             {
@@ -39,6 +41,11 @@ namespace Taxjar
                 if (parameters.GetType().GetProperty("headers") != null)
                 {
                     this.headers = (IDictionary<string, string>) parameters.GetType().GetProperty("headers").GetValue(parameters);
+                }
+
+                if (parameters.GetType().GetProperty("timeout") != null)
+                {
+                    this.timeout = (int) parameters.GetType().GetProperty("timeout").GetValue(parameters);
                 }
             }
 
@@ -78,6 +85,8 @@ namespace Taxjar
             {
                 request.AddHeader(header.Key, header.Value);
             }
+
+            request.Timeout = this.timeout * 1000;
 
             return request;
         }


### PR DESCRIPTION
This PR resolves #11 to expose RestSharp connection errors such as timeouts. It also introduces custom global timeouts when instantiating the API client:

```csharp
var client = new TaxjarApi("API_TOKEN", new {
    apiUrl = "https://api.taxjar.com",
    timeout = 30
});
```