### PR TITLE
RestSharp v106.5.x Support

### DIFF
--- a/build/TaxJar.nuspec
+++ b/build/TaxJar.nuspec
@@ -21,7 +21,7 @@
     <dependencies>
       <group>
         <dependency id="Newtonsoft.Json" version="11.0.2" />
-        <dependency id="RestSharp" version="106.2.1" />
+        <dependency id="RestSharp" version="[106.2.1,107.0.0)" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Taxjar.Tests/TaxJar.Tests.csproj
+++ b/src/Taxjar.Tests/TaxJar.Tests.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="RestSharp" Version="106.2.1" />
+    <PackageReference Include="RestSharp" Version="106.5.3" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="WireMock.Net.StandAlone" Version="1.0.3.14" />
     <PackageReference Include="DotNetEnv" Version="1.1.0" />

--- a/src/Taxjar/Taxjar.csproj
+++ b/src/Taxjar/Taxjar.csproj
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="RestSharp" Version="106.2.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="RestSharp" Version="106.5.3" />
   </ItemGroup>
 
 </Project>

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using RestSharp;
+using RestRequest = RestSharp.RestRequest;
 
 namespace Taxjar
 {


### PR DESCRIPTION
This PR updates RestSharp to the latest version and fixes a strange error when upgrading from v106.4.x to v106.5.x:

> System.MissingMethodException: void RestSharp.RestRequest..ctor(string,RestSharp.Method)