### PR TITLE
Address Validation

### DIFF
--- a/src/Taxjar.Tests/Fixtures/addresses.json
+++ b/src/Taxjar.Tests/Fixtures/addresses.json
@@ -1,0 +1,11 @@
+﻿{
+  "addresses": [
+    {
+      "zip": "85297-2176",
+      "street": "3301 S Greenfield Rd",
+      "state": "AZ",
+      "country": "US",
+      "city": "Gilbert"
+    }
+  ]
+}

--- a/src/Taxjar.Tests/Fixtures/addresses_multiple.json
+++ b/src/Taxjar.Tests/Fixtures/addresses_multiple.json
@@ -1,0 +1,18 @@
+﻿{
+  "addresses": [
+    {
+      "zip": "85007-3646",
+      "street": "1109 S 9th Ave",
+      "state": "AZ",
+      "country": "US",
+      "city": "Phoenix"
+    },
+    {
+      "zip": "85006-2734",
+      "street": "1109 N 9th St",
+      "state": "AZ",
+      "country": "US",
+      "city": "Phoenix"
+    }
+  ]
+}

--- a/src/Taxjar.Tests/Validations.cs
+++ b/src/Taxjar.Tests/Validations.cs
@@ -8,7 +8,80 @@ namespace Taxjar.Tests
 	[TestFixture]
 	public class ValidationTests
 	{
-		[Test]
+        [SetUp]
+        public static void Init()
+        {
+            Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "http://localhost:9191" });
+            Bootstrap.server.ResetMappings();
+        }
+
+        [Test]
+        public void when_validating_an_address()
+        {
+            var body = JsonConvert.DeserializeObject<AddressValidationResponse>(TaxjarFixture.GetJSON("addresses.json"));
+
+            Bootstrap.server.Given(
+                Request.Create()
+                    .WithPath("/v2/addresses/validate")
+                    .UsingPost()
+            ).RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithBodyAsJson(body)
+            );
+
+            var addresses = Bootstrap.client.ValidateAddress(new
+            {
+                country = "US",
+                state = "AZ",
+                zip = "85297",
+                city = "Gilbert",
+                street = "3301 South Greenfield Rd"
+            });
+
+            Assert.AreEqual("85297-2176", addresses[0].Zip);
+            Assert.AreEqual("3301 S Greenfield Rd", addresses[0].Street);
+            Assert.AreEqual("AZ", addresses[0].State);
+            Assert.AreEqual("US", addresses[0].Country);
+            Assert.AreEqual("Gilbert", addresses[0].City);
+        }
+
+        [Test]
+        public void when_validating_an_address_with_multiple_matches()
+        {
+            var body = JsonConvert.DeserializeObject<AddressValidationResponse>(TaxjarFixture.GetJSON("addresses_multiple.json"));
+
+            Bootstrap.server.Given(
+                Request.Create()
+                    .WithPath("/v2/addresses/validate")
+                    .UsingPost()
+            ).RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithBodyAsJson(body)
+            );
+
+            var addresses = Bootstrap.client.ValidateAddress(new
+            {
+                state = "AZ",
+                city = "Phoenix",
+                street = "1109 9th"
+            });
+
+            Assert.AreEqual("85007-3646", addresses[0].Zip);
+            Assert.AreEqual("1109 S 9th Ave", addresses[0].Street);
+            Assert.AreEqual("AZ", addresses[0].State);
+            Assert.AreEqual("US", addresses[0].Country);
+            Assert.AreEqual("Phoenix", addresses[0].City);
+
+            Assert.AreEqual("85006-2734", addresses[1].Zip);
+            Assert.AreEqual("1109 N 9th St", addresses[1].Street);
+            Assert.AreEqual("AZ", addresses[1].State);
+            Assert.AreEqual("US", addresses[1].Country);
+            Assert.AreEqual("Phoenix", addresses[1].City);
+        }
+
+        [Test]
 		public void when_validating_a_vat_number()
 		{
             var body = JsonConvert.DeserializeObject<ValidationResponse>(TaxjarFixture.GetJSON("validation.json"));

--- a/src/Taxjar/Entities/TaxjarAddressValidation.cs
+++ b/src/Taxjar/Entities/TaxjarAddressValidation.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Taxjar
+{
+    public class AddressValidationResponse
+    {
+        [JsonProperty("addresses")]
+        public List<Address> Addresses { get; set; }
+    }
+
+    public class Address
+    {
+        [JsonProperty("country")]
+        public string Country { get; set; }
+
+        [JsonProperty("zip")]
+        public string Zip { get; set; }
+
+        [JsonProperty("state")]
+        public string State { get; set; }
+
+        [JsonProperty("city")]
+        public string City { get; set; }
+
+        [JsonProperty("street")]
+        public string Street { get; set; }
+    }
+}

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -292,6 +292,13 @@ namespace Taxjar
             return nexusRegionsRequest.Regions;
         }
 
+        public virtual List<Address> ValidateAddress(object parameters)
+        {
+            var res = SendRequest("addresses/validate", parameters, Method.POST);
+            var addressValidationRequest = JsonConvert.DeserializeObject<AddressValidationResponse>(res);
+            return addressValidationRequest.Addresses;
+        }
+
         public virtual ValidationResponseAttributes Validate(object parameters)
         {
             var res = SendRequest("validation", parameters, Method.GET);


### PR DESCRIPTION
This PR adds support for TaxJar's address validation beta endpoint via `ValidateAddress`. At this time, address validation is only available for TaxJar Plus customers.