### PR TITLE
Update Transaction Request Entity Fix

### DIFF
--- a/src/Taxjar.Tests/Transactions.cs
+++ b/src/Taxjar.Tests/Transactions.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using NUnit.Framework;
+using System;
 using System.Net;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -200,7 +201,42 @@ namespace Taxjar.Tests
 			AssertOrder(order);
 		}
 
-		[Test]
+        [Test]
+        public void when_updating_an_order_transaction_with_missing_transaction_id()
+        {
+            var body = JsonConvert.DeserializeObject<OrderResponse>(TaxjarFixture.GetJSON("orders/show.json"));
+
+            Bootstrap.server.Given(
+                Request.Create()
+                    .WithPath("/v2/transactions/orders/123")
+                    .UsingPut()
+            ).RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithBodyAsJson(body)
+            );
+
+            var systemException = Assert.Throws<Exception>(() => Bootstrap.client.UpdateOrder(new
+            {
+                amount = 17.95,
+                shipping = 2,
+                line_items = new[] {
+                    new {
+                        quantity = 1,
+                        product_identifier = "12-34243-0",
+                        description = "Heavy Widget",
+                        product_tax_code = "20010",
+                        unit_price = 15,
+                        discount = 0,
+                        sales_tax = 0.95
+                    }
+                }
+            }));
+
+            Assert.AreEqual("Missing transaction ID for `UpdateOrder`", systemException.Message);
+        }
+
+        [Test]
 		public void when_deleting_an_order_transaction()
 		{
             Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });
@@ -331,7 +367,42 @@ namespace Taxjar.Tests
 			AssertRefund(refund);
 		}
 
-		[Test]
+        [Test]
+        public void when_updating_a_refund_transaction_with_missing_transaction_id()
+        {
+            var body = JsonConvert.DeserializeObject<RefundResponse>(TaxjarFixture.GetJSON("refunds/show.json"));
+
+            Bootstrap.server.Given(
+                Request.Create()
+                    .WithPath("/v2/transactions/refunds/321")
+                    .UsingPut()
+            ).RespondWith(
+                Response.Create()
+                    .WithStatusCode(HttpStatusCode.Created)
+                    .WithBodyAsJson(body)
+            );
+
+            var systemException = Assert.Throws<Exception>(() => Bootstrap.client.UpdateRefund(new
+            {
+                amount = 17.95,
+                shipping = 2,
+                line_items = new[] {
+                    new {
+                        quantity = 1,
+                        product_identifier = "12-34243-0",
+                        description = "Heavy Widget",
+                        product_tax_code = "20010",
+                        unit_price = 15,
+                        discount = 0,
+                        sales_tax = 0.95
+                    }
+                }
+            }));
+
+            Assert.AreEqual("Missing transaction ID for `UpdateRefund`", systemException.Message);
+        }
+
+        [Test]
 		public void when_deleting_a_refund_transaction()
 		{
             Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -200,7 +200,14 @@ namespace Taxjar
 
         public virtual OrderResponseAttributes UpdateOrder(object parameters)
         {
-            var transactionId = parameters.GetType().GetProperty("transaction_id").GetValue(parameters).ToString();
+            var transactionIdProp = parameters.GetType().GetProperty("transaction_id") ?? parameters.GetType().GetProperty("TransactionId");
+
+            if (transactionIdProp == null)
+            {
+                throw new Exception("Missing transaction ID for `UpdateOrder`");
+            }
+
+            var transactionId = transactionIdProp.GetValue(parameters).ToString();
             var res = SendRequest("transactions/orders/" + transactionId, parameters, Method.PUT);
             var orderRequest = JsonConvert.DeserializeObject<OrderResponse>(res);
             return orderRequest.Order;
@@ -236,7 +243,13 @@ namespace Taxjar
 
         public virtual RefundResponseAttributes UpdateRefund(object parameters)
         {
-            var transactionId = parameters.GetType().GetProperty("transaction_id").GetValue(parameters).ToString();
+            var transactionIdProp = parameters.GetType().GetProperty("transaction_id") ?? parameters.GetType().GetProperty("TransactionId");
+
+            if (transactionIdProp == null) {
+                throw new Exception("Missing transaction ID for `UpdateRefund`");
+            }
+
+            var transactionId = transactionIdProp.GetValue(parameters).ToString();
             var res = SendRequest("transactions/refunds/" + transactionId, parameters, Method.PUT);
             var refundRequest = JsonConvert.DeserializeObject<RefundResponse>(res);
             return refundRequest.Refund;


### PR DESCRIPTION
This PR fixes a null reference error when passing an `Order` or `Refund` request entity to the `UpdateOrder` or `UpdateRefund` methods. Typically we check for `transaction_id` from an anonymous object. Now we'll look for either `transaction_id` or `TransactionId`.