### PR TITLE
RestSharp v106.5.4

### DIFF
--- a/build/TaxJar.nuspec
+++ b/build/TaxJar.nuspec
@@ -21,7 +21,7 @@
     <dependencies>
       <group>
         <dependency id="Newtonsoft.Json" version="11.0.2" />
-        <dependency id="RestSharp" version="[106.2.1,106.5.0)" />
+        <dependency id="RestSharp" version="[106.5.4,107.0.0)" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Taxjar.Tests/TaxJar.Tests.csproj
+++ b/src/Taxjar.Tests/TaxJar.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="RestSharp" Version="106.2.1" />
+    <PackageReference Include="RestSharp" Version="106.5.4" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="WireMock.Net.StandAlone" Version="1.0.3.14" />
     <PackageReference Include="DotNetEnv" Version="1.1.0" />

--- a/src/Taxjar/Taxjar.csproj
+++ b/src/Taxjar/Taxjar.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="RestSharp" Version="106.2.1" />
+    <PackageReference Include="RestSharp" Version="106.5.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Upgrade to the latest version of RestSharp and require as minimum version in NuGet. This PR should be merged for a major version release (v3.0) of our API client.