### PR TITLE
Update Customer Request Entity Fix

### DIFF
--- a/src/Taxjar.Tests/Customers.cs
+++ b/src/Taxjar.Tests/Customers.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using NUnit.Framework;
+using System;
 using System.Net;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -146,6 +147,41 @@ namespace Taxjar.Tests
             });
 
             AssertCustomer(customer);
+        }
+
+        [Test]
+        public void when_updating_a_customer_with_missing_customer_id()
+        {
+            var body = JsonConvert.DeserializeObject<CustomerResponse>(TaxjarFixture.GetJSON("customers/show.json"));
+
+            Bootstrap.server.Given(
+                Request.Create()
+                    .WithPath("/v2/customers/123")
+                    .UsingPut()
+            ).RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithBodyAsJson(body)
+            );
+
+            var systemException = Assert.Throws<Exception>(() => Bootstrap.client.UpdateCustomer(new
+            {
+                exemption_type = "wholesale",
+                name = "Sterling Cooper",
+                exempt_regions = new[] {
+                    new {
+                      country = "US",
+                      state = "NY"
+                    }
+                },
+                country = "US",
+                state = "NY",
+                zip = "10010",
+                city = "New York",
+                street = "405 Madison Ave"
+            }));
+
+            Assert.AreEqual("Missing customer ID for `UpdateCustomer`", systemException.Message);
         }
 
         [Test]

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -285,7 +285,14 @@ namespace Taxjar
 
         public virtual CustomerResponseAttributes UpdateCustomer(object parameters)
         {
-            var customerId = parameters.GetType().GetProperty("customer_id").GetValue(parameters).ToString();
+            var customerIdProp = parameters.GetType().GetProperty("customer_id") ?? parameters.GetType().GetProperty("CustomerId");
+
+            if (customerIdProp == null)
+            {
+                throw new Exception("Missing customer ID for `UpdateCustomer`");
+            }
+
+            var customerId = customerIdProp.GetValue(parameters).ToString();
             var res = SendRequest("customers/" + customerId, parameters, Method.PUT);
             var customerRequest = JsonConvert.DeserializeObject<CustomerResponse>(res);
             return customerRequest.Customer;


### PR DESCRIPTION
This PR fixes a null reference error when passing a `Customer` request entity to the `UpdateCustomer` method. Typically we check for `customer_id` from an anonymous object. Now we'll look for either `customer_id` or `CustomerId`.