### PR TITLE
Normalize tax breakdown attributes

### DIFF
--- a/src/Taxjar.Tests/Taxes.cs
+++ b/src/Taxjar.Tests/Taxes.cs
@@ -71,7 +71,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual(0.10875, rates.Breakdown.Shipping.CombinedTaxRate);
 			Assert.AreEqual(10, rates.Breakdown.Shipping.StateTaxableAmount);
 			Assert.AreEqual(0.4, rates.Breakdown.Shipping.StateAmount);
-			Assert.AreEqual(0.04, rates.Breakdown.Shipping.StateSalesTaxRate);
+			Assert.AreEqual(0.04, rates.Breakdown.Shipping.StateTaxRate);
 			Assert.AreEqual(10, rates.Breakdown.Shipping.CountyTaxableAmount);
 			Assert.AreEqual(0.1, rates.Breakdown.Shipping.CountyAmount);
 			Assert.AreEqual(0.01, rates.Breakdown.Shipping.CountyTaxRate);
@@ -104,7 +104,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual(4.44, rates.Breakdown.LineItems[0].TaxCollectable);
 			Assert.AreEqual(0.10875, rates.Breakdown.LineItems[0].CombinedTaxRate);
 			Assert.AreEqual(50, rates.Breakdown.LineItems[0].StateTaxableAmount);
-			Assert.AreEqual(0.04, rates.Breakdown.LineItems[0].StateSalesTaxRate);
+			Assert.AreEqual(0.04, rates.Breakdown.LineItems[0].StateTaxRate);
 			Assert.AreEqual(2, rates.Breakdown.LineItems[0].StateAmount);
 			Assert.AreEqual(50, rates.Breakdown.LineItems[0].CountyTaxableAmount);
 			Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].CountyTaxRate);
@@ -113,7 +113,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual(0.04875, rates.Breakdown.LineItems[0].CityTaxRate);
 			Assert.AreEqual(2.44, rates.Breakdown.LineItems[0].CityAmount);
 			Assert.AreEqual(50, rates.Breakdown.LineItems[0].SpecialDistrictTaxableAmount);
-			Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].SpecialTaxRate);
+			Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].SpecialDistrictTaxRate);
 			Assert.AreEqual(0.5, rates.Breakdown.LineItems[0].SpecialDistrictAmount);
 		}
 
@@ -173,7 +173,7 @@ namespace Taxjar.Tests
             Assert.AreEqual(0.10875, rates.Breakdown.Shipping.CombinedTaxRate);
             Assert.AreEqual(10, rates.Breakdown.Shipping.StateTaxableAmount);
             Assert.AreEqual(0.4, rates.Breakdown.Shipping.StateAmount);
-            Assert.AreEqual(0.04, rates.Breakdown.Shipping.StateSalesTaxRate);
+            Assert.AreEqual(0.04, rates.Breakdown.Shipping.StateTaxRate);
             Assert.AreEqual(10, rates.Breakdown.Shipping.CountyTaxableAmount);
             Assert.AreEqual(0.1, rates.Breakdown.Shipping.CountyAmount);
             Assert.AreEqual(0.01, rates.Breakdown.Shipping.CountyTaxRate);
@@ -206,7 +206,7 @@ namespace Taxjar.Tests
             Assert.AreEqual(4.44, rates.Breakdown.LineItems[0].TaxCollectable);
             Assert.AreEqual(0.10875, rates.Breakdown.LineItems[0].CombinedTaxRate);
             Assert.AreEqual(50, rates.Breakdown.LineItems[0].StateTaxableAmount);
-            Assert.AreEqual(0.04, rates.Breakdown.LineItems[0].StateSalesTaxRate);
+            Assert.AreEqual(0.04, rates.Breakdown.LineItems[0].StateTaxRate);
             Assert.AreEqual(2, rates.Breakdown.LineItems[0].StateAmount);
             Assert.AreEqual(50, rates.Breakdown.LineItems[0].CountyTaxableAmount);
             Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].CountyTaxRate);
@@ -215,7 +215,7 @@ namespace Taxjar.Tests
             Assert.AreEqual(0.04875, rates.Breakdown.LineItems[0].CityTaxRate);
             Assert.AreEqual(2.44, rates.Breakdown.LineItems[0].CityAmount);
             Assert.AreEqual(50, rates.Breakdown.LineItems[0].SpecialDistrictTaxableAmount);
-            Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].SpecialTaxRate);
+            Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].SpecialDistrictTaxRate);
             Assert.AreEqual(0.5, rates.Breakdown.LineItems[0].SpecialDistrictAmount);
         }
 

--- a/src/Taxjar/Entities/TaxjarTaxBreakdownLineItem.cs
+++ b/src/Taxjar/Entities/TaxjarTaxBreakdownLineItem.cs
@@ -8,7 +8,7 @@ namespace Taxjar
 		public string Id { get; set; }
 
 		[JsonProperty("state_sales_tax_rate")]
-		public decimal StateSalesTaxRate { get; set; }
+		public decimal StateTaxRate { get; set; }
 
 		[JsonProperty("state_amount")]
 		public decimal StateAmount { get; set; }
@@ -23,7 +23,7 @@ namespace Taxjar
 		public decimal SpecialDistrictTaxableAmount { get; set; }
 
 		[JsonProperty("special_tax_rate")]
-		public decimal SpecialTaxRate { get; set; }
+		public decimal SpecialDistrictTaxRate { get; set; }
 
 		[JsonProperty("special_district_amount")]
 		public decimal SpecialDistrictAmount { get; set; }

--- a/src/Taxjar/Entities/TaxjarTaxBreakdownShipping.cs
+++ b/src/Taxjar/Entities/TaxjarTaxBreakdownShipping.cs
@@ -5,7 +5,7 @@ namespace Taxjar
 	public class TaxBreakdownShipping : Breakdown
 	{
 		[JsonProperty("state_sales_tax_rate")]
-		public decimal StateSalesTaxRate { get; set; }
+		public decimal StateTaxRate { get; set; }
 
 		[JsonProperty("state_amount")]
 		public decimal StateAmount { get; set; }


### PR DESCRIPTION
Entity properties should be consistent across breakdown types to make it easier to drill down into tax breakdown responses. This PR makes a couple tweaks to reduce confusion. **It's a breaking change that requires a major version update.**