### PR TITLE
Handle null values for EU rate attributes

### DIFF
--- a/src/Taxjar/Entities/TaxjarRate.cs
+++ b/src/Taxjar/Entities/TaxjarRate.cs
@@ -55,16 +55,16 @@ namespace Taxjar
 		[JsonProperty("standard_rate")]
 		public decimal StandardRate { get; set; }
 
-		[JsonProperty("reduced_rate")]
+		[JsonProperty("reduced_rate", NullValueHandling = NullValueHandling.Ignore)]
 		public decimal ReducedRate { get; set; }
 
-		[JsonProperty("super_reduced_rate")]
+		[JsonProperty("super_reduced_rate", NullValueHandling = NullValueHandling.Ignore)]
 		public decimal SuperReducedRate { get; set; }
 
-		[JsonProperty("parking_rate")]
+		[JsonProperty("parking_rate", NullValueHandling = NullValueHandling.Ignore)]
 		public decimal ParkingRate { get; set; }
 
-		[JsonProperty("distance_sale_threshold")]
+		[JsonProperty("distance_sale_threshold", NullValueHandling = NullValueHandling.Ignore)]
 		public decimal DistanceSaleThreshold { get; set; }
 	}
 


### PR DESCRIPTION
This PR resolves an issue with a recent change made to our API. EU response attributes from `/v2/rates` are returning null values instead of `0.0`. We'll fix it from both the API and client. Resolves #25.