### PR TITLE
Add `provider` param to transaction methods

### DIFF
--- a/src/Taxjar.Tests/Fixtures/orders/delete.json
+++ b/src/Taxjar.Tests/Fixtures/orders/delete.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": null,
     "transaction_reference_id": null,
+    "provider": "api",
     "from_country": null,
     "from_zip": null,
     "from_state": null,

--- a/src/Taxjar.Tests/Fixtures/orders/show.json
+++ b/src/Taxjar.Tests/Fixtures/orders/show.json
@@ -3,6 +3,7 @@
     "transaction_id": "123",
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
+    "provider": "api",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",

--- a/src/Taxjar.Tests/Fixtures/refunds/delete.json
+++ b/src/Taxjar.Tests/Fixtures/refunds/delete.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": null,
     "transaction_reference_id": null,
+    "provider": "api",
     "from_country": null,
     "from_zip": null,
     "from_state": null,

--- a/src/Taxjar.Tests/Fixtures/refunds/show.json
+++ b/src/Taxjar.Tests/Fixtures/refunds/show.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
     "transaction_reference_id": "123",
+    "provider": "api",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",

--- a/src/Taxjar.Tests/TaxJar.Tests.csproj
+++ b/src/Taxjar.Tests/TaxJar.Tests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
     <PackageReference Include="RestSharp" Version="106.5.4" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="WireMock.Net.StandAlone" Version="1.0.3.14" />
+    <PackageReference Include="WireMock.Net.StandAlone" Version="1.0.19.0" />
     <PackageReference Include="DotNetEnv" Version="1.1.0" />
   </ItemGroup>
 

--- a/src/Taxjar.Tests/Transactions.cs
+++ b/src/Taxjar.Tests/Transactions.cs
@@ -23,6 +23,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual("123", order.TransactionId);
 			Assert.AreEqual(10649, order.UserId);
 			Assert.AreEqual("2015-05-14T00:00:00Z", order.TransactionDate);
+			Assert.AreEqual("api", order.Provider);
 			Assert.AreEqual("US", order.ToCountry);
 			Assert.AreEqual("90002", order.ToZip);
 			Assert.AreEqual("CA", order.ToState);
@@ -45,6 +46,7 @@ namespace Taxjar.Tests
 		{
 			Assert.AreEqual("123", order.TransactionId);
 			Assert.AreEqual(null, order.TransactionDate);
+			Assert.AreEqual("api", order.Provider);
 			Assert.AreEqual(0, order.Amount);
 			Assert.AreEqual(0, order.Shipping);
 			Assert.AreEqual(0, order.SalesTax);
@@ -56,6 +58,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual("123", refund.TransactionReferenceId);
 			Assert.AreEqual(10649, refund.UserId);
 			Assert.AreEqual("2015-05-14T00:00:00Z", refund.TransactionDate);
+			Assert.AreEqual("api", refund.Provider);
 			Assert.AreEqual("US", refund.ToCountry);
 			Assert.AreEqual("90002", refund.ToZip);
 			Assert.AreEqual("CA", refund.ToState);
@@ -78,6 +81,7 @@ namespace Taxjar.Tests
 		{
 			Assert.AreEqual("321", refund.TransactionId);
 			Assert.AreEqual(null, refund.TransactionDate);
+			Assert.AreEqual("api", refund.Provider);
 			Assert.AreEqual(0, refund.Amount);
 			Assert.AreEqual(0, refund.Shipping);
 			Assert.AreEqual(0, refund.SalesTax);
@@ -101,7 +105,8 @@ namespace Taxjar.Tests
 
 			var orders = Bootstrap.client.ListOrders(new {
 				from_transaction_date = "2015/05/01",
-				to_transaction_date = "2015/05/31"
+				to_transaction_date = "2015/05/31",
+				provider = "api"
 			});
 
 			Assert.AreEqual("123", orders[0]);
@@ -127,7 +132,8 @@ namespace Taxjar.Tests
             var orders = await Bootstrap.client.ListOrdersAsync(new
             {
                 from_transaction_date = "2015/05/01",
-                to_transaction_date = "2015/05/31"
+                to_transaction_date = "2015/05/31",
+                provider = "api"
             });
 
             Assert.AreEqual("123", orders[0]);
@@ -150,7 +156,9 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var order = Bootstrap.client.ShowOrder("123");
+			var order = Bootstrap.client.ShowOrder("123", new {
+				provider = "api"
+			});
 			AssertOrder(order);
 		}
 
@@ -170,7 +178,9 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-            var order = await Bootstrap.client.ShowOrderAsync("123");
+            var order = await Bootstrap.client.ShowOrderAsync("123", new {
+                provider = "api"
+            });
 
             AssertOrder(order);
         }
@@ -194,6 +204,7 @@ namespace Taxjar.Tests
 			var order = Bootstrap.client.CreateOrder(new {
 				transaction_id = "123",
 				transaction_date = "2015/05/04",
+				provider = "api",
 				to_country = "US",
 				to_zip = "90002",
 				to_city = "Los Angeles",
@@ -236,6 +247,7 @@ namespace Taxjar.Tests
             {
                 transaction_id = "123",
                 transaction_date = "2015/05/04",
+                provider = "api",
                 to_country = "US",
                 to_zip = "90002",
                 to_city = "Los Angeles",
@@ -372,7 +384,9 @@ namespace Taxjar.Tests
 		{
             Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });
 
-			var order = Bootstrap.client.DeleteOrder("123");
+			var order = Bootstrap.client.DeleteOrder("123", new {
+				provider = "api"
+			});
 			AssertDeletedOrder(order);
 		}
 
@@ -381,7 +395,9 @@ namespace Taxjar.Tests
         {
             Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });
 
-            var order = await Bootstrap.client.DeleteOrderAsync("123");
+            var order = await Bootstrap.client.DeleteOrderAsync("123", new {
+                provider = "api"
+            });
             AssertDeletedOrder(order);
         }
 
@@ -404,7 +420,8 @@ namespace Taxjar.Tests
 			var refunds = Bootstrap.client.ListRefunds(new
 			{
 				from_transaction_date = "2015/05/01",
-				to_transaction_date = "2015/05/31"
+				to_transaction_date = "2015/05/31",
+				provider = "api"
 			});
 
 			Assert.AreEqual("321", refunds[0]);
@@ -430,7 +447,8 @@ namespace Taxjar.Tests
             var refunds = await Bootstrap.client.ListRefundsAsync(new
             {
                 from_transaction_date = "2015/05/01",
-                to_transaction_date = "2015/05/31"
+                to_transaction_date = "2015/05/31",
+                provider = "api"
             });
 
             Assert.AreEqual("321", refunds[0]);
@@ -453,7 +471,9 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var refund = Bootstrap.client.ShowRefund("321");
+			var refund = Bootstrap.client.ShowRefund("321", new {
+				provider = "api"
+			});
 			AssertRefund(refund);
 		}
 
@@ -473,7 +493,9 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-            var refund = await Bootstrap.client.ShowRefundAsync("321");
+            var refund = await Bootstrap.client.ShowRefundAsync("321", new {
+                provider = "api"
+            });
             AssertRefund(refund);
         }
 
@@ -498,6 +520,7 @@ namespace Taxjar.Tests
 				transaction_id = "321",
 				transaction_date = "2015/05/04",
 				transaction_reference_id = "123",
+				provider = "api",
 				to_country = "US",
 				to_zip = "90002",
 				to_city = "Los Angeles",
@@ -541,6 +564,7 @@ namespace Taxjar.Tests
                 transaction_id = "321",
                 transaction_date = "2015/05/04",
                 transaction_reference_id = "123",
+                provider = "api",
                 to_country = "US",
                 to_zip = "90002",
                 to_city = "Los Angeles",
@@ -677,7 +701,9 @@ namespace Taxjar.Tests
 		{
             Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });
 
-			var refund = Bootstrap.client.DeleteRefund("321");
+			var refund = Bootstrap.client.DeleteRefund("321", new {
+				provider = "api"
+			});
 			AssertDeletedRefund(refund);
 		}
 
@@ -686,7 +712,9 @@ namespace Taxjar.Tests
         {
             Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });
 
-            var refund = await Bootstrap.client.DeleteRefundAsync("321");
+            var refund = await Bootstrap.client.DeleteRefundAsync("321", new {
+                provider = "api"
+            });
             AssertDeletedRefund(refund);
         }
     }

--- a/src/Taxjar.Tests/Transactions.cs
+++ b/src/Taxjar.Tests/Transactions.cs
@@ -382,7 +382,18 @@ namespace Taxjar.Tests
         [Test]
 		public void when_deleting_an_order_transaction()
 		{
-            Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });
+            var body = JsonConvert.DeserializeObject<OrderResponse>(TaxjarFixture.GetJSON("orders/delete.json"));
+
+            Bootstrap.server.Given(
+                Request.Create()
+                    .WithPath("/v2/transactions/orders/123")
+                    .UsingDelete()
+            ).RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBodyAsJson(body)
+            );
 
 			var order = Bootstrap.client.DeleteOrder("123", new {
 				provider = "api"
@@ -393,7 +404,18 @@ namespace Taxjar.Tests
         [Test]
         public async Task when_deleting_an_order_transaction_async()
         {
-            Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });
+            var body = JsonConvert.DeserializeObject<OrderResponse>(TaxjarFixture.GetJSON("orders/delete.json"));
+
+            Bootstrap.server.Given(
+                Request.Create()
+                    .WithPath("/v2/transactions/orders/123")
+                    .UsingDelete()
+            ).RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBodyAsJson(body)
+            );
 
             var order = await Bootstrap.client.DeleteOrderAsync("123", new {
                 provider = "api"
@@ -699,7 +721,18 @@ namespace Taxjar.Tests
         [Test]
 		public void when_deleting_a_refund_transaction()
 		{
-            Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });
+            var body = JsonConvert.DeserializeObject<RefundResponse>(TaxjarFixture.GetJSON("refunds/delete.json"));
+
+            Bootstrap.server.Given(
+                Request.Create()
+                    .WithPath("/v2/transactions/refunds/321")
+                    .UsingDelete()
+            ).RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBodyAsJson(body)
+            );
 
 			var refund = Bootstrap.client.DeleteRefund("321", new {
 				provider = "api"
@@ -710,7 +743,18 @@ namespace Taxjar.Tests
         [Test]
         public async Task when_deleting_a_refund_transaction_async()
         {
-            Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "https://api.sandbox.taxjar.com" });
+            var body = JsonConvert.DeserializeObject<RefundResponse>(TaxjarFixture.GetJSON("refunds/delete.json"));
+
+            Bootstrap.server.Given(
+                Request.Create()
+                    .WithPath("/v2/transactions/refunds/321")
+                    .UsingDelete()
+            ).RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBodyAsJson(body)
+            );
 
             var refund = await Bootstrap.client.DeleteRefundAsync("321", new {
                 provider = "api"

--- a/src/Taxjar/Entities/TaxjarOrder.cs
+++ b/src/Taxjar/Entities/TaxjarOrder.cs
@@ -26,6 +26,9 @@ namespace Taxjar
         [JsonProperty("transaction_date")]
         public string TransactionDate { get; set; }
 
+        [JsonProperty("provider")]
+        public string Provider { get; set; }
+
         [JsonProperty("from_country")]
         public string FromCountry { get; set; }
 
@@ -76,6 +79,9 @@ namespace Taxjar
 
         [JsonProperty("transaction_date")]
         public string TransactionDate { get; set; }
+
+        [JsonProperty("provider")]
+        public string Provider { get; set; }
 
         [JsonProperty("from_country")]
         public string FromCountry { get; set; }
@@ -133,5 +139,8 @@ namespace Taxjar
 
         [JsonProperty("to_transaction_date")]
         public string ToTransactionDate { get; set; }
+
+        [JsonProperty("provider")]
+        public string Provider { get; set; }
     }
 }

--- a/src/Taxjar/Entities/TaxjarRefund.cs
+++ b/src/Taxjar/Entities/TaxjarRefund.cs
@@ -29,6 +29,9 @@ namespace Taxjar
         [JsonProperty("transaction_date")]
         public string TransactionDate { get; set; }
 
+        [JsonProperty("provider")]
+        public string Provider { get; set; }
+
         [JsonProperty("from_country")]
         public string FromCountry { get; set; }
 
@@ -69,7 +72,7 @@ namespace Taxjar
         public decimal SalesTax { get; set; }
 
         [JsonProperty("line_items")]
-        public List<LineItem> LineItems { get; set; }        
+        public List<LineItem> LineItems { get; set; }
     }
 
     public class Refund
@@ -82,6 +85,9 @@ namespace Taxjar
 
         [JsonProperty("transaction_date")]
         public string TransactionDate { get; set; }
+
+        [JsonProperty("provider")]
+        public string Provider { get; set; }
 
         [JsonProperty("from_country")]
         public string FromCountry { get; set; }
@@ -139,5 +145,8 @@ namespace Taxjar
 
         [JsonProperty("to_transaction_date")]
         public string ToTransactionDate { get; set; }
+
+        [JsonProperty("provider")]
+        public string Provider { get; set; }
     }
 }

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -79,7 +79,7 @@ namespace Taxjar
         {
             var request = new RestRequest(action, method)
             {
-                RequestFormat = DataFormat.Json 
+                RequestFormat = DataFormat.Json
             };
 
             request.AddHeader("Authorization", "Bearer " + apiToken);
@@ -174,7 +174,7 @@ namespace Taxjar
             return Attribute.IsDefined(type, typeof(CompilerGeneratedAttribute), false)
                 && type.IsGenericType && type.Name.Contains("AnonymousType")
                 && (type.Name.StartsWith("<>") || type.Name.StartsWith("VB$"))
-                && (type.Attributes & TypeAttributes.NotPublic) == TypeAttributes.NotPublic;   
+                && (type.Attributes & TypeAttributes.NotPublic) == TypeAttributes.NotPublic;
         }
 
         public virtual List<Category> Categories()
@@ -201,9 +201,9 @@ namespace Taxjar
             return response.Orders;
         }
 
-        public virtual OrderResponseAttributes ShowOrder(string transactionId)
+        public virtual OrderResponseAttributes ShowOrder(string transactionId, object parameters = null)
         {
-            var response = SendRequest<OrderResponse>("transactions/orders/" + transactionId, null, Method.GET);
+            var response = SendRequest<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.GET);
             return response.Order;
         }
 
@@ -227,9 +227,9 @@ namespace Taxjar
             return response.Order;
         }
 
-        public virtual OrderResponseAttributes DeleteOrder(string transactionId)
+        public virtual OrderResponseAttributes DeleteOrder(string transactionId, object parameters = null)
         {
-            var response = SendRequest<OrderResponse>("transactions/orders/" + transactionId, null, Method.DELETE);
+            var response = SendRequest<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.DELETE);
             return response.Order;
         }
 
@@ -239,9 +239,9 @@ namespace Taxjar
             return response.Refunds;
         }
 
-        public virtual RefundResponseAttributes ShowRefund(string transactionId)
+        public virtual RefundResponseAttributes ShowRefund(string transactionId, object parameters = null)
         {
-            var response = SendRequest<RefundResponse>("transactions/refunds/" + transactionId, null, Method.GET);
+            var response = SendRequest<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.GET);
             return response.Refund;
         }
 
@@ -264,9 +264,9 @@ namespace Taxjar
             return response.Refund;
         }
 
-        public virtual RefundResponseAttributes DeleteRefund(string transactionId)
+        public virtual RefundResponseAttributes DeleteRefund(string transactionId, object parameters = null)
         {
-            var response = SendRequest<RefundResponse>("transactions/refunds/" + transactionId, null, Method.DELETE);
+            var response = SendRequest<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.DELETE);
             return response.Refund;
         }
 
@@ -356,9 +356,9 @@ namespace Taxjar
             return response.Orders;
         }
 
-        public virtual async Task<OrderResponseAttributes> ShowOrderAsync(string transactionId)
+        public virtual async Task<OrderResponseAttributes> ShowOrderAsync(string transactionId, object parameters = null)
         {
-            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, null, Method.GET);
+            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.GET);
             return response.Order;
         }
 
@@ -375,9 +375,9 @@ namespace Taxjar
             return response.Order;
         }
 
-        public virtual async Task<OrderResponseAttributes> DeleteOrderAsync(string transactionId)
+        public virtual async Task<OrderResponseAttributes> DeleteOrderAsync(string transactionId, object parameters = null)
         {
-            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, null, Method.DELETE);
+            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.DELETE);
             return response.Order;
         }
 
@@ -387,9 +387,9 @@ namespace Taxjar
             return response.Refunds;
         }
 
-        public virtual async Task<RefundResponseAttributes> ShowRefundAsync(string transactionId)
+        public virtual async Task<RefundResponseAttributes> ShowRefundAsync(string transactionId, object parameters = null)
         {
-            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, null, Method.GET);
+            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.GET);
             return response.Refund;
         }
 
@@ -406,9 +406,9 @@ namespace Taxjar
             return response.Refund;
         }
 
-        public virtual async Task<RefundResponseAttributes> DeleteRefundAsync(string transactionId)
+        public virtual async Task<RefundResponseAttributes> DeleteRefundAsync(string transactionId, object parameters = null)
         {
-            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, null, Method.DELETE);
+            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.DELETE);
             return response.Refund;
         }
 


### PR DESCRIPTION
This PR implements the new `provider` param, which currently adds marketplace exemption support for Amazon, eBay, Etsy, and Walmart transactions. `provider` defaults to `api`.

The `provider` param will be supported in methods:

- `ListOrders`
- `ListOrdersAsync`
- `ShowOrder`
- `ShowOrderAsync`
- `CreateOrder`
- `CreateOrderAsync`
- `DeleteOrder`
- `DeleteOrderAsync`
- `ListRefunds`
- `ListRefundsAsync`
- `ShowRefund`
- `ShowRefundAsync`
- `CreateRefund`
- `CreateRefundAsync`
- `DeleteRefund`
- `DeleteRefundAsync`