### PR TITLE
Add support for order-level exemptions via `exemption_type` param

### DIFF
--- a/src/Taxjar.Tests/Fixtures/orders/delete.json
+++ b/src/Taxjar.Tests/Fixtures/orders/delete.json
@@ -5,6 +5,7 @@
     "transaction_date": null,
     "transaction_reference_id": null,
     "provider": "api",
+    "exemption_type": null,
     "from_country": null,
     "from_zip": null,
     "from_state": null,

--- a/src/Taxjar.Tests/Fixtures/orders/show.json
+++ b/src/Taxjar.Tests/Fixtures/orders/show.json
@@ -4,6 +4,7 @@
     "user_id": 10649,
     "transaction_date": "2015-05-14T00:00:00Z",
     "provider": "api",
+    "exemption_type": "non_exempt",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",

--- a/src/Taxjar.Tests/Fixtures/refunds/delete.json
+++ b/src/Taxjar.Tests/Fixtures/refunds/delete.json
@@ -5,6 +5,7 @@
     "transaction_date": null,
     "transaction_reference_id": null,
     "provider": "api",
+    "exemption_type": null,
     "from_country": null,
     "from_zip": null,
     "from_state": null,

--- a/src/Taxjar.Tests/Fixtures/refunds/show.json
+++ b/src/Taxjar.Tests/Fixtures/refunds/show.json
@@ -5,6 +5,7 @@
     "transaction_date": "2015-05-14T00:00:00Z",
     "transaction_reference_id": "123",
     "provider": "api",
+    "exemption_type": "non_exempt",
     "to_country": "US",
     "to_zip": "90002",
     "to_state": "CA",

--- a/src/Taxjar.Tests/Fixtures/taxes.json
+++ b/src/Taxjar.Tests/Fixtures/taxes.json
@@ -8,6 +8,7 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "jurisdictions": {
       "country": "US",
       "state": "NY",

--- a/src/Taxjar.Tests/Fixtures/taxes_canada.json
+++ b/src/Taxjar.Tests/Fixtures/taxes_canada.json
@@ -8,6 +8,7 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "jurisdictions": {
       "country": "CA",
       "state": "ON"

--- a/src/Taxjar.Tests/Fixtures/taxes_international.json
+++ b/src/Taxjar.Tests/Fixtures/taxes_international.json
@@ -8,6 +8,7 @@
     "has_nexus": true,
     "freight_taxable": true,
     "tax_source": "destination",
+    "exemption_type": "non_exempt",
     "jurisdictions": {
       "country": "FI"
     },

--- a/src/Taxjar.Tests/Taxes.cs
+++ b/src/Taxjar.Tests/Taxes.cs
@@ -41,6 +41,7 @@ namespace Taxjar.Tests
 				to_state = "NY",
 				amount = 60,
 				shipping = 10,
+				exemption_type = "non_exempt",
 				line_items = new[] {
 					new
 					{
@@ -58,6 +59,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual(true, rates.HasNexus);
 			Assert.AreEqual(true, rates.FreightTaxable);
 			Assert.AreEqual("destination", rates.TaxSource);
+			Assert.AreEqual("non_exempt", rates.ExemptionType);
 
             // Jurisdictions
             Assert.AreEqual("US", rates.Jurisdictions.Country);
@@ -143,6 +145,7 @@ namespace Taxjar.Tests
                 to_state = "NY",
                 amount = 60,
                 shipping = 10,
+                exemption_type = "non_exempt",
                 line_items = new[] {
                     new
                     {
@@ -160,6 +163,7 @@ namespace Taxjar.Tests
             Assert.AreEqual(true, rates.HasNexus);
             Assert.AreEqual(true, rates.FreightTaxable);
             Assert.AreEqual("destination", rates.TaxSource);
+            Assert.AreEqual("non_exempt", rates.ExemptionType);
 
             // Jurisdictions
             Assert.AreEqual("US", rates.Jurisdictions.Country);
@@ -243,6 +247,7 @@ namespace Taxjar.Tests
 				to_zip = "00150",
 				amount = 16.95,
 				shipping = 10,
+				exemption_type = "non_exempt",
 				line_items = new[] {
 					new
 					{
@@ -257,6 +262,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual(true, rates.HasNexus);
 			Assert.AreEqual(true, rates.FreightTaxable);
 			Assert.AreEqual("destination", rates.TaxSource);
+			Assert.AreEqual("non_exempt", rates.ExemptionType);
 
             // Jurisdictions
             Assert.AreEqual("FI", rates.Jurisdictions.Country);
@@ -311,6 +317,7 @@ namespace Taxjar.Tests
 				to_state = "ON",
 				amount = 16.95,
 				shipping = 10,
+				exemption_type = "non_exempt",
 				line_items = new[] {
 					new
 					{
@@ -328,6 +335,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual(true, rates.HasNexus);
 			Assert.AreEqual(true, rates.FreightTaxable);
 			Assert.AreEqual("destination", rates.TaxSource);
+			Assert.AreEqual("non_exempt", rates.ExemptionType);
 
             // Jurisdictions
             Assert.AreEqual("CA", rates.Jurisdictions.Country);

--- a/src/Taxjar.Tests/Transactions.cs
+++ b/src/Taxjar.Tests/Transactions.cs
@@ -24,6 +24,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual(10649, order.UserId);
 			Assert.AreEqual("2015-05-14T00:00:00Z", order.TransactionDate);
 			Assert.AreEqual("api", order.Provider);
+			Assert.AreEqual("non_exempt", order.ExemptionType);
 			Assert.AreEqual("US", order.ToCountry);
 			Assert.AreEqual("90002", order.ToZip);
 			Assert.AreEqual("CA", order.ToState);
@@ -47,6 +48,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual("123", order.TransactionId);
 			Assert.AreEqual(null, order.TransactionDate);
 			Assert.AreEqual("api", order.Provider);
+			Assert.AreEqual(null, order.ExemptionType);
 			Assert.AreEqual(0, order.Amount);
 			Assert.AreEqual(0, order.Shipping);
 			Assert.AreEqual(0, order.SalesTax);
@@ -59,6 +61,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual(10649, refund.UserId);
 			Assert.AreEqual("2015-05-14T00:00:00Z", refund.TransactionDate);
 			Assert.AreEqual("api", refund.Provider);
+			Assert.AreEqual("non_exempt", refund.ExemptionType);
 			Assert.AreEqual("US", refund.ToCountry);
 			Assert.AreEqual("90002", refund.ToZip);
 			Assert.AreEqual("CA", refund.ToState);
@@ -82,6 +85,7 @@ namespace Taxjar.Tests
 			Assert.AreEqual("321", refund.TransactionId);
 			Assert.AreEqual(null, refund.TransactionDate);
 			Assert.AreEqual("api", refund.Provider);
+			Assert.AreEqual(null, refund.ExemptionType);
 			Assert.AreEqual(0, refund.Amount);
 			Assert.AreEqual(0, refund.Shipping);
 			Assert.AreEqual(0, refund.SalesTax);
@@ -205,6 +209,7 @@ namespace Taxjar.Tests
 				transaction_id = "123",
 				transaction_date = "2015/05/04",
 				provider = "api",
+				exemption_type = "non_exempt",
 				to_country = "US",
 				to_zip = "90002",
 				to_city = "Los Angeles",
@@ -248,6 +253,7 @@ namespace Taxjar.Tests
                 transaction_id = "123",
                 transaction_date = "2015/05/04",
                 provider = "api",
+                exemption_type = "non_exempt",
                 to_country = "US",
                 to_zip = "90002",
                 to_city = "Los Angeles",
@@ -291,6 +297,7 @@ namespace Taxjar.Tests
 				transaction_id = "123",
 				amount = 17.95,
 				shipping = 2,
+				exemption_type = "non_exempt",
 				line_items = new[] {
 					new {
 						quantity = 1,
@@ -328,6 +335,7 @@ namespace Taxjar.Tests
                 transaction_id = "123",
                 amount = 17.95,
                 shipping = 2,
+                exemption_type = "non_exempt",
                 line_items = new[] {
                     new {
                         quantity = 1,
@@ -363,6 +371,7 @@ namespace Taxjar.Tests
             {
                 amount = 17.95,
                 shipping = 2,
+                exemption_type = "non_exempt",
                 line_items = new[] {
                     new {
                         quantity = 1,
@@ -543,6 +552,7 @@ namespace Taxjar.Tests
 				transaction_date = "2015/05/04",
 				transaction_reference_id = "123",
 				provider = "api",
+				exemption_type = "non_exempt",
 				to_country = "US",
 				to_zip = "90002",
 				to_city = "Los Angeles",
@@ -587,6 +597,7 @@ namespace Taxjar.Tests
                 transaction_date = "2015/05/04",
                 transaction_reference_id = "123",
                 provider = "api",
+                exemption_type = "non_exempt",
                 to_country = "US",
                 to_zip = "90002",
                 to_city = "Los Angeles",
@@ -630,6 +641,7 @@ namespace Taxjar.Tests
 				transaction_id = "321",
 				amount = 17.95,
 				shipping = 2,
+				exemption_type = "non_exempt",
 				line_items = new[] {
 					new {
 						quantity = 1,
@@ -667,6 +679,7 @@ namespace Taxjar.Tests
                 transaction_id = "321",
                 amount = 17.95,
                 shipping = 2,
+                exemption_type = "non_exempt",
                 line_items = new[] {
                     new {
                         quantity = 1,
@@ -702,6 +715,7 @@ namespace Taxjar.Tests
             {
                 amount = 17.95,
                 shipping = 2,
+                exemption_type = "non_exempt",
                 line_items = new[] {
                     new {
                         quantity = 1,

--- a/src/Taxjar/Entities/TaxjarOrder.cs
+++ b/src/Taxjar/Entities/TaxjarOrder.cs
@@ -29,6 +29,9 @@ namespace Taxjar
         [JsonProperty("provider")]
         public string Provider { get; set; }
 
+        [JsonProperty("exemption_type")]
+        public string ExemptionType { get; set; }
+
         [JsonProperty("from_country")]
         public string FromCountry { get; set; }
 
@@ -82,6 +85,9 @@ namespace Taxjar
 
         [JsonProperty("provider")]
         public string Provider { get; set; }
+
+        [JsonProperty("exemption_type")]
+        public string ExemptionType { get; set; }
 
         [JsonProperty("from_country")]
         public string FromCountry { get; set; }

--- a/src/Taxjar/Entities/TaxjarRefund.cs
+++ b/src/Taxjar/Entities/TaxjarRefund.cs
@@ -32,6 +32,9 @@ namespace Taxjar
         [JsonProperty("provider")]
         public string Provider { get; set; }
 
+        [JsonProperty("exemption_type")]
+        public string ExemptionType { get; set; }
+
         [JsonProperty("from_country")]
         public string FromCountry { get; set; }
 
@@ -88,6 +91,9 @@ namespace Taxjar
 
         [JsonProperty("provider")]
         public string Provider { get; set; }
+
+        [JsonProperty("exemption_type")]
+        public string ExemptionType { get; set; }
 
         [JsonProperty("from_country")]
         public string FromCountry { get; set; }

--- a/src/Taxjar/Entities/TaxjarTax.cs
+++ b/src/Taxjar/Entities/TaxjarTax.cs
@@ -35,6 +35,9 @@ namespace Taxjar
 		[JsonProperty("tax_source")]
 		public string TaxSource { get; set; }
 
+        [JsonProperty("exemption_type")]
+        public string ExemptionType { get; set; }
+
         [JsonProperty("jurisdictions")]
         public TaxJurisdictions Jurisdictions { get; set; }
 
@@ -82,6 +85,9 @@ namespace Taxjar
 
         [JsonProperty("customer_id")]
         public string CustomerId { get; set; }
+
+        [JsonProperty("exemption_type")]
+        public string ExemptionType { get; set; }
 
         [JsonProperty("nexus_addresses")]
         public List<NexusAddress> NexusAddresses { get; set; }


### PR DESCRIPTION
This change introduces an optional `exemption_type` parameter for:

- TaxForOrder
- TaxForOrderAsync
- CreateOrder
- CreateOrderAsync
- UpdateOrder
- UpdateOrderAsync
- CreateRefund
- CreateRefundAsync
- UpdateRefund
- UpdateRefundAsync

The allowable values are: `government`, `wholesale`, `other`, and `non_exempt`.

With the exception of `non_exempt`, a request with one of these values indicates a transaction that is fully-exempt at the order level.

When also using the existing optional `customer_id` parameter, an `exemption_type` value of `non_exempt` specifies that a transaction belonging to an otherwise exempt customer be processed as taxable.

With the exception of `non_exempt`, when usage of the `customer_id` param qualifies the transaction as exempt, the customer's exemption type would be applied, rather than the `exemption_type` submitted in the request.