### PR TITLE
Keep whitespace consistent

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.sln]
+indent_style = tab
+
+[*.{json,csproj,props,targets}]
+indent_size = 2

--- a/src/Taxjar.Tests/Categories.cs
+++ b/src/Taxjar.Tests/Categories.cs
@@ -6,12 +6,12 @@ using WireMock.ResponseBuilders;
 
 namespace Taxjar.Tests
 {
-	[TestFixture]
+    [TestFixture]
     public class CategoriesTests
-	{
-		[Test]
-		public void when_listing_tax_categories()
-		{
+    {
+        [Test]
+        public void when_listing_tax_categories()
+        {
             var body = JsonConvert.DeserializeObject<CategoriesResponse>(TaxjarFixture.GetJSON("categories.json"));
 
             Bootstrap.server.Given(
@@ -31,7 +31,7 @@ namespace Taxjar.Tests
             Assert.AreEqual("Clothing", categories[0].Name);
             Assert.AreEqual("20010", categories[0].ProductTaxCode);
             Assert.AreEqual("All human wearing apparel suitable for general use", categories[0].Description);
-		}
+        }
 
         [Test]
         public async Task when_listing_tax_categories_async()

--- a/src/Taxjar.Tests/Client.cs
+++ b/src/Taxjar.Tests/Client.cs
@@ -7,9 +7,9 @@ using WireMock.ResponseBuilders;
 
 namespace Taxjar.Tests
 {
-	[TestFixture]
+    [TestFixture]
     public class ClientTests
-	{
+    {
         [SetUp]
         public static void Init()
         {
@@ -17,17 +17,17 @@ namespace Taxjar.Tests
             Bootstrap.server.ResetMappings();
         }
 
-		[Test, Order(1)]
-		public void instantiates_client_with_api_token()
-		{
+        [Test, Order(1)]
+        public void instantiates_client_with_api_token()
+        {
             Bootstrap.client = new TaxjarApi(Bootstrap.apiKey);
-		}
+        }
 
-		[Test, Order(2)]
-		public void instantiates_client_with_additional_arguments()
-		{
+        [Test, Order(2)]
+        public void instantiates_client_with_additional_arguments()
+        {
             Bootstrap.client = new TaxjarApi(Bootstrap.apiKey, new { apiUrl = "http://localhost:9191" });
-		}
+        }
 
         [Test, Order(3)]
         public void instantiates_client_with_custom_headers()
@@ -93,8 +93,8 @@ namespace Taxjar.Tests
         }
 
         [Test, Order(9)]
-		public void returns_exception_with_invalid_api_token()
-		{
+        public void returns_exception_with_invalid_api_token()
+        {
             Bootstrap.server.Given(
                 Request.Create()
                     .WithPath("/v2/categories")
@@ -108,11 +108,11 @@ namespace Taxjar.Tests
 
             var taxjarException = Assert.Throws<TaxjarException>(() => Bootstrap.client.Categories());
 
-			Assert.AreEqual(HttpStatusCode.Unauthorized, taxjarException.HttpStatusCode);
-			Assert.AreEqual("Unauthorized", taxjarException.TaxjarError.Error);
-			Assert.AreEqual("Not authorized for route 'GET /v2/categories'", taxjarException.TaxjarError.Detail);
-			Assert.AreEqual("401", taxjarException.TaxjarError.StatusCode);
-		}
+            Assert.AreEqual(HttpStatusCode.Unauthorized, taxjarException.HttpStatusCode);
+            Assert.AreEqual("Unauthorized", taxjarException.TaxjarError.Error);
+            Assert.AreEqual("Not authorized for route 'GET /v2/categories'", taxjarException.TaxjarError.Detail);
+            Assert.AreEqual("401", taxjarException.TaxjarError.StatusCode);
+        }
 
         [Test, Order(10)]
         public void returns_exception_with_timeout()
@@ -134,5 +134,5 @@ namespace Taxjar.Tests
 
             Assert.AreEqual("The operation has timed out.", systemException.Message);
         }
-	}
+    }
 }

--- a/src/Taxjar.Tests/Infrastructure/TaxjarFixture.cs
+++ b/src/Taxjar.Tests/Infrastructure/TaxjarFixture.cs
@@ -4,18 +4,17 @@ using Newtonsoft.Json.Linq;
 
 namespace Taxjar.Tests
 {
-	public class TaxjarFixture
-	{
-		public static string GetJSON(string fixturePath)
-		{
-			using (StreamReader file = File.OpenText(Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "../../../", "Fixtures", fixturePath)))
-			using (JsonTextReader reader = new JsonTextReader(file))
-			{
-				JObject response = (JObject)JToken.ReadFrom(reader);
+    public class TaxjarFixture
+    {
+        public static string GetJSON(string fixturePath)
+        {
+            using (StreamReader file = File.OpenText(Path.Combine(System.AppDomain.CurrentDomain.BaseDirectory, "../../../", "Fixtures", fixturePath)))
+            using (JsonTextReader reader = new JsonTextReader(file))
+            {
+                JObject response = (JObject)JToken.ReadFrom(reader);
                 var resString = response.ToString(Formatting.None).Replace(@"\", "");
                 return response.ToString(Formatting.None).Replace(@"\", "");
-			}
-		}
-	}
+            }
+        }
+    }
 }
-

--- a/src/Taxjar.Tests/Nexus.cs
+++ b/src/Taxjar.Tests/Nexus.cs
@@ -6,12 +6,12 @@ using WireMock.ResponseBuilders;
 
 namespace Taxjar.Tests
 {
-	[TestFixture]
+    [TestFixture]
     public class NexusTests
-	{
-		[Test]
-		public void when_listing_nexus_regions()
-		{
+    {
+        [Test]
+        public void when_listing_nexus_regions()
+        {
             var body = JsonConvert.DeserializeObject<NexusRegionsResponse>(TaxjarFixture.GetJSON("nexus_regions.json"));
 
             Bootstrap.server.Given(
@@ -27,12 +27,12 @@ namespace Taxjar.Tests
 
             var nexusRegions = Bootstrap.client.NexusRegions();
 
-			Assert.AreEqual(3, nexusRegions.Count);
-			Assert.AreEqual("US", nexusRegions[0].CountryCode);
-			Assert.AreEqual("United States", nexusRegions[0].Country);
-			Assert.AreEqual("CA", nexusRegions[0].RegionCode);
-			Assert.AreEqual("California", nexusRegions[0].Region);
-		}
+            Assert.AreEqual(3, nexusRegions.Count);
+            Assert.AreEqual("US", nexusRegions[0].CountryCode);
+            Assert.AreEqual("United States", nexusRegions[0].Country);
+            Assert.AreEqual("CA", nexusRegions[0].RegionCode);
+            Assert.AreEqual("California", nexusRegions[0].Region);
+        }
 
         [Test]
         public async Task when_listing_nexus_regions_async()

--- a/src/Taxjar.Tests/Rates.cs
+++ b/src/Taxjar.Tests/Rates.cs
@@ -6,12 +6,12 @@ using WireMock.ResponseBuilders;
 
 namespace Taxjar.Tests
 {
-	[TestFixture]
+    [TestFixture]
     public class RatesTests
-	{
-		[Test]
-		public void when_showing_tax_rates_for_a_location()
-		{
+    {
+        [Test]
+        public void when_showing_tax_rates_for_a_location()
+        {
             var body = JsonConvert.DeserializeObject<RateResponse>(TaxjarFixture.GetJSON("rates.json"));
 
             Bootstrap.server.Given(
@@ -25,19 +25,19 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var rates = Bootstrap.client.RatesForLocation("90002");
+            var rates = Bootstrap.client.RatesForLocation("90002");
 
-			Assert.AreEqual("90002", rates.Zip);
-			Assert.AreEqual("CA", rates.State);
-			Assert.AreEqual(0.065, rates.StateRate);
-			Assert.AreEqual("LOS ANGELES", rates.County);
-			Assert.AreEqual(0.01, rates.CountyRate);
-			Assert.AreEqual("WATTS", rates.City);
-			Assert.AreEqual(0, rates.CityRate);
-			Assert.AreEqual(0.015, rates.CombinedDistrictRate);
-			Assert.AreEqual(0.09, rates.CombinedRate);
+            Assert.AreEqual("90002", rates.Zip);
+            Assert.AreEqual("CA", rates.State);
+            Assert.AreEqual(0.065, rates.StateRate);
+            Assert.AreEqual("LOS ANGELES", rates.County);
+            Assert.AreEqual(0.01, rates.CountyRate);
+            Assert.AreEqual("WATTS", rates.City);
+            Assert.AreEqual(0, rates.CityRate);
+            Assert.AreEqual(0.015, rates.CombinedDistrictRate);
+            Assert.AreEqual(0.09, rates.CombinedRate);
             Assert.AreEqual(false, rates.FreightTaxable);
-		}
+        }
 
         [Test]
         public async Task when_showing_tax_rates_for_a_location_async()
@@ -70,8 +70,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_showing_tax_rates_for_a_location_sst()
-		{
+        public void when_showing_tax_rates_for_a_location_sst()
+        {
             var body = JsonConvert.DeserializeObject<RateResponse>(TaxjarFixture.GetJSON("rates_sst.json"));
 
             Bootstrap.server.Given(
@@ -85,25 +85,25 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var rates = Bootstrap.client.RatesForLocation("05495-2086");
+            var rates = Bootstrap.client.RatesForLocation("05495-2086");
 
-			Assert.AreEqual("05495-2086", rates.Zip);
+            Assert.AreEqual("05495-2086", rates.Zip);
             Assert.AreEqual("US", rates.Country);
             Assert.AreEqual(0, rates.CountryRate);
-			Assert.AreEqual("VT", rates.State);
-			Assert.AreEqual(0.06, rates.StateRate);
-			Assert.AreEqual("CHITTENDEN", rates.County);
-			Assert.AreEqual(0, rates.CountyRate);
-			Assert.AreEqual("WILLISTON", rates.City);
-			Assert.AreEqual(0, rates.CityRate);
-			Assert.AreEqual(0.01, rates.CombinedDistrictRate);
-			Assert.AreEqual(0.07, rates.CombinedRate);
-			Assert.AreEqual(true, rates.FreightTaxable);
-		}
+            Assert.AreEqual("VT", rates.State);
+            Assert.AreEqual(0.06, rates.StateRate);
+            Assert.AreEqual("CHITTENDEN", rates.County);
+            Assert.AreEqual(0, rates.CountyRate);
+            Assert.AreEqual("WILLISTON", rates.City);
+            Assert.AreEqual(0, rates.CityRate);
+            Assert.AreEqual(0.01, rates.CombinedDistrictRate);
+            Assert.AreEqual(0.07, rates.CombinedRate);
+            Assert.AreEqual(true, rates.FreightTaxable);
+        }
 
-		[Test]
-		public void when_showing_tax_rates_for_a_location_ca()
-		{
+        [Test]
+        public void when_showing_tax_rates_for_a_location_ca()
+        {
             var body = JsonConvert.DeserializeObject<RateResponse>(TaxjarFixture.GetJSON("rates_ca.json"));
 
             Bootstrap.server.Given(
@@ -117,19 +117,19 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var rates = Bootstrap.client.RatesForLocation("V5K0A1");
+            var rates = Bootstrap.client.RatesForLocation("V5K0A1");
 
-			Assert.AreEqual("V5K0A1", rates.Zip);
+            Assert.AreEqual("V5K0A1", rates.Zip);
             Assert.AreEqual("Vancouver", rates.City);
             Assert.AreEqual("BC", rates.State);
-			Assert.AreEqual("CA", rates.Country);
+            Assert.AreEqual("CA", rates.Country);
             Assert.AreEqual(0.12, rates.CombinedRate);
             Assert.AreEqual(true, rates.FreightTaxable);
-		}
+        }
 
-		[Test]
-		public void when_showing_tax_rates_for_a_location_au()
-		{
+        [Test]
+        public void when_showing_tax_rates_for_a_location_au()
+        {
             var body = JsonConvert.DeserializeObject<RateResponse>(TaxjarFixture.GetJSON("rates_au.json"));
 
             Bootstrap.server.Given(
@@ -143,18 +143,18 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var rates = Bootstrap.client.RatesForLocation("2060");
+            var rates = Bootstrap.client.RatesForLocation("2060");
 
-			Assert.AreEqual("2060", rates.Zip);
-			Assert.AreEqual("AU", rates.Country);
+            Assert.AreEqual("2060", rates.Zip);
+            Assert.AreEqual("AU", rates.Country);
             Assert.AreEqual(0.1, rates.CountryRate);
-			Assert.AreEqual(0.1, rates.CombinedRate);
-			Assert.AreEqual(true, rates.FreightTaxable);
-		}
+            Assert.AreEqual(0.1, rates.CombinedRate);
+            Assert.AreEqual(true, rates.FreightTaxable);
+        }
 
-		[Test]
-		public void when_showing_tax_rates_for_a_location_eu()
-		{
+        [Test]
+        public void when_showing_tax_rates_for_a_location_eu()
+        {
             var body = JsonConvert.DeserializeObject<RateResponse>(TaxjarFixture.GetJSON("rates_eu.json"));
 
             Bootstrap.server.Given(
@@ -168,9 +168,9 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var rates = Bootstrap.client.RatesForLocation("00150");
+            var rates = Bootstrap.client.RatesForLocation("00150");
 
-			Assert.AreEqual("FI", rates.Country);
+            Assert.AreEqual("FI", rates.Country);
             Assert.AreEqual("Finland", rates.Name);
             Assert.AreEqual(0.24, rates.StandardRate);
             Assert.AreEqual(0, rates.ReducedRate);
@@ -178,6 +178,6 @@ namespace Taxjar.Tests
             Assert.AreEqual(0, rates.ParkingRate);
             Assert.AreEqual(0, rates.DistanceSaleThreshold);
             Assert.AreEqual(true, rates.FreightTaxable);
-		}
-	}
+        }
+    }
 }

--- a/src/Taxjar.Tests/SummarizedRates.cs
+++ b/src/Taxjar.Tests/SummarizedRates.cs
@@ -6,12 +6,12 @@ using WireMock.ResponseBuilders;
 
 namespace Taxjar.Tests
 {
-	[TestFixture]
-	public class SummarizedRateTests
-	{
-		[Test]
-		public void when_summarizing_tax_rates_for_all_regions()
-		{
+    [TestFixture]
+    public class SummarizedRateTests
+    {
+        [Test]
+        public void when_summarizing_tax_rates_for_all_regions()
+        {
             var body = JsonConvert.DeserializeObject<SummaryRatesResponse>(TaxjarFixture.GetJSON("summary_rates.json"));
 
             Bootstrap.server.Given(
@@ -27,16 +27,16 @@ namespace Taxjar.Tests
 
             var summaryRates = Bootstrap.client.SummaryRates();
 
-			Assert.AreEqual(3, summaryRates.Count);
-			Assert.AreEqual("US", summaryRates[0].CountryCode);
-			Assert.AreEqual("United States", summaryRates[0].Country);
-			Assert.AreEqual("CA", summaryRates[0].RegionCode);
-			Assert.AreEqual("California", summaryRates[0].Region);
-			Assert.AreEqual("State Tax", summaryRates[0].MinimumRate.Label);
-			Assert.AreEqual(0.065, summaryRates[0].MinimumRate.Rate);
-			Assert.AreEqual("Tax", summaryRates[0].AverageRate.Label);
-			Assert.AreEqual(0.0827, summaryRates[0].AverageRate.Rate);
-		}
+            Assert.AreEqual(3, summaryRates.Count);
+            Assert.AreEqual("US", summaryRates[0].CountryCode);
+            Assert.AreEqual("United States", summaryRates[0].Country);
+            Assert.AreEqual("CA", summaryRates[0].RegionCode);
+            Assert.AreEqual("California", summaryRates[0].Region);
+            Assert.AreEqual("State Tax", summaryRates[0].MinimumRate.Label);
+            Assert.AreEqual(0.065, summaryRates[0].MinimumRate.Rate);
+            Assert.AreEqual("Tax", summaryRates[0].AverageRate.Label);
+            Assert.AreEqual(0.0827, summaryRates[0].AverageRate.Rate);
+        }
 
         [Test]
         public async Task when_summarizing_tax_rates_for_all_regions_async()

--- a/src/Taxjar.Tests/Taxes.cs
+++ b/src/Taxjar.Tests/Taxes.cs
@@ -6,9 +6,9 @@ using WireMock.ResponseBuilders;
 
 namespace Taxjar.Tests
 {
-	[TestFixture]
-	public class TaxesTests
-	{
+    [TestFixture]
+    public class TaxesTests
+    {
         [SetUp]
         public static void Init()
         {
@@ -16,9 +16,9 @@ namespace Taxjar.Tests
             Bootstrap.server.ResetMappings();
         }
 
-		[Test]
-		public void when_calculating_sales_tax_for_an_order()
-		{
+        [Test]
+        public void when_calculating_sales_tax_for_an_order()
+        {
             var body = JsonConvert.DeserializeObject<TaxResponse>(TaxjarFixture.GetJSON("taxes.json"));
 
             Bootstrap.server.Given(
@@ -32,34 +32,34 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var rates = Bootstrap.client.TaxForOrder(new {
-				from_country =  "US",
-				from_zip = "12207",
-				from_state = "NY",
-				to_country = "US",
-				to_zip = "10001",
-				to_state = "NY",
-				amount = 60,
-				shipping = 10,
-				exemption_type = "non_exempt",
-				line_items = new[] {
-					new
-					{
-						quantity = 1,
-						unit_price = 50
-					}
-				}
-			});
+            var rates = Bootstrap.client.TaxForOrder(new {
+                from_country =  "US",
+                from_zip = "12207",
+                from_state = "NY",
+                to_country = "US",
+                to_zip = "10001",
+                to_state = "NY",
+                amount = 60,
+                shipping = 10,
+                exemption_type = "non_exempt",
+                line_items = new[] {
+                    new
+                    {
+                        quantity = 1,
+                        unit_price = 50
+                    }
+                }
+            });
 
-			Assert.AreEqual(60, rates.OrderTotalAmount);
-			Assert.AreEqual(10, rates.Shipping);
-			Assert.AreEqual(60, rates.TaxableAmount);
-			Assert.AreEqual(6.53, rates.AmountToCollect);
-			Assert.AreEqual(0.10875, rates.Rate);
-			Assert.AreEqual(true, rates.HasNexus);
-			Assert.AreEqual(true, rates.FreightTaxable);
-			Assert.AreEqual("destination", rates.TaxSource);
-			Assert.AreEqual("non_exempt", rates.ExemptionType);
+            Assert.AreEqual(60, rates.OrderTotalAmount);
+            Assert.AreEqual(10, rates.Shipping);
+            Assert.AreEqual(60, rates.TaxableAmount);
+            Assert.AreEqual(6.53, rates.AmountToCollect);
+            Assert.AreEqual(0.10875, rates.Rate);
+            Assert.AreEqual(true, rates.HasNexus);
+            Assert.AreEqual(true, rates.FreightTaxable);
+            Assert.AreEqual("destination", rates.TaxSource);
+            Assert.AreEqual("non_exempt", rates.ExemptionType);
 
             // Jurisdictions
             Assert.AreEqual("US", rates.Jurisdictions.Country);
@@ -69,55 +69,55 @@ namespace Taxjar.Tests
 
             // Breakdowns
             Assert.AreEqual(10, rates.Breakdown.Shipping.TaxableAmount);
-			Assert.AreEqual(0.89, rates.Breakdown.Shipping.TaxCollectable);
-			Assert.AreEqual(0.10875, rates.Breakdown.Shipping.CombinedTaxRate);
-			Assert.AreEqual(10, rates.Breakdown.Shipping.StateTaxableAmount);
-			Assert.AreEqual(0.4, rates.Breakdown.Shipping.StateAmount);
-			Assert.AreEqual(0.04, rates.Breakdown.Shipping.StateSalesTaxRate);
-			Assert.AreEqual(10, rates.Breakdown.Shipping.CountyTaxableAmount);
-			Assert.AreEqual(0.1, rates.Breakdown.Shipping.CountyAmount);
-			Assert.AreEqual(0.01, rates.Breakdown.Shipping.CountyTaxRate);
-			Assert.AreEqual(10, rates.Breakdown.Shipping.CityTaxableAmount);
-			Assert.AreEqual(0.49, rates.Breakdown.Shipping.CityAmount);
-			Assert.AreEqual(0.04875, rates.Breakdown.Shipping.CityTaxRate);
+            Assert.AreEqual(0.89, rates.Breakdown.Shipping.TaxCollectable);
+            Assert.AreEqual(0.10875, rates.Breakdown.Shipping.CombinedTaxRate);
+            Assert.AreEqual(10, rates.Breakdown.Shipping.StateTaxableAmount);
+            Assert.AreEqual(0.4, rates.Breakdown.Shipping.StateAmount);
+            Assert.AreEqual(0.04, rates.Breakdown.Shipping.StateSalesTaxRate);
+            Assert.AreEqual(10, rates.Breakdown.Shipping.CountyTaxableAmount);
+            Assert.AreEqual(0.1, rates.Breakdown.Shipping.CountyAmount);
+            Assert.AreEqual(0.01, rates.Breakdown.Shipping.CountyTaxRate);
+            Assert.AreEqual(10, rates.Breakdown.Shipping.CityTaxableAmount);
+            Assert.AreEqual(0.49, rates.Breakdown.Shipping.CityAmount);
+            Assert.AreEqual(0.04875, rates.Breakdown.Shipping.CityTaxRate);
             Assert.AreEqual(10, rates.Breakdown.Shipping.SpecialDistrictTaxableAmount);
             Assert.AreEqual(0.01, rates.Breakdown.Shipping.SpecialDistrictTaxRate);
             Assert.AreEqual(0.1, rates.Breakdown.Shipping.SpecialDistrictAmount);
 
-			Assert.AreEqual(60, rates.Breakdown.TaxableAmount);
-			Assert.AreEqual(6.53, rates.Breakdown.TaxCollectable);
-			Assert.AreEqual(0.10875, rates.Breakdown.CombinedTaxRate);
-			Assert.AreEqual(60, rates.Breakdown.StateTaxableAmount);
-			Assert.AreEqual(0.04, rates.Breakdown.StateTaxRate);
-			Assert.AreEqual(2.4, rates.Breakdown.StateTaxCollectable);
-			Assert.AreEqual(60, rates.Breakdown.CountyTaxableAmount);
-			Assert.AreEqual(0.01, rates.Breakdown.CountyTaxRate);
-			Assert.AreEqual(0.6, rates.Breakdown.CountyTaxCollectable);
-			Assert.AreEqual(60, rates.Breakdown.CityTaxableAmount);
-			Assert.AreEqual(0.04875, rates.Breakdown.CityTaxRate);
-			Assert.AreEqual(2.93, rates.Breakdown.CityTaxCollectable);
-			Assert.AreEqual(60, rates.Breakdown.SpecialDistrictTaxableAmount);
-			Assert.AreEqual(0.01, rates.Breakdown.SpecialDistrictTaxRate);
-			Assert.AreEqual(0.6, rates.Breakdown.SpecialDistrictTaxCollectable);
+            Assert.AreEqual(60, rates.Breakdown.TaxableAmount);
+            Assert.AreEqual(6.53, rates.Breakdown.TaxCollectable);
+            Assert.AreEqual(0.10875, rates.Breakdown.CombinedTaxRate);
+            Assert.AreEqual(60, rates.Breakdown.StateTaxableAmount);
+            Assert.AreEqual(0.04, rates.Breakdown.StateTaxRate);
+            Assert.AreEqual(2.4, rates.Breakdown.StateTaxCollectable);
+            Assert.AreEqual(60, rates.Breakdown.CountyTaxableAmount);
+            Assert.AreEqual(0.01, rates.Breakdown.CountyTaxRate);
+            Assert.AreEqual(0.6, rates.Breakdown.CountyTaxCollectable);
+            Assert.AreEqual(60, rates.Breakdown.CityTaxableAmount);
+            Assert.AreEqual(0.04875, rates.Breakdown.CityTaxRate);
+            Assert.AreEqual(2.93, rates.Breakdown.CityTaxCollectable);
+            Assert.AreEqual(60, rates.Breakdown.SpecialDistrictTaxableAmount);
+            Assert.AreEqual(0.01, rates.Breakdown.SpecialDistrictTaxRate);
+            Assert.AreEqual(0.6, rates.Breakdown.SpecialDistrictTaxCollectable);
 
-			// Line Items
-			Assert.AreEqual("1", rates.Breakdown.LineItems[0].Id);
-			Assert.AreEqual(50, rates.Breakdown.LineItems[0].TaxableAmount);
-			Assert.AreEqual(4.44, rates.Breakdown.LineItems[0].TaxCollectable);
-			Assert.AreEqual(0.10875, rates.Breakdown.LineItems[0].CombinedTaxRate);
-			Assert.AreEqual(50, rates.Breakdown.LineItems[0].StateTaxableAmount);
-			Assert.AreEqual(0.04, rates.Breakdown.LineItems[0].StateSalesTaxRate);
-			Assert.AreEqual(2, rates.Breakdown.LineItems[0].StateAmount);
-			Assert.AreEqual(50, rates.Breakdown.LineItems[0].CountyTaxableAmount);
-			Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].CountyTaxRate);
-			Assert.AreEqual(0.5, rates.Breakdown.LineItems[0].CountyAmount);
-			Assert.AreEqual(50, rates.Breakdown.LineItems[0].CityTaxableAmount);
-			Assert.AreEqual(0.04875, rates.Breakdown.LineItems[0].CityTaxRate);
-			Assert.AreEqual(2.44, rates.Breakdown.LineItems[0].CityAmount);
-			Assert.AreEqual(50, rates.Breakdown.LineItems[0].SpecialDistrictTaxableAmount);
-			Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].SpecialTaxRate);
-			Assert.AreEqual(0.5, rates.Breakdown.LineItems[0].SpecialDistrictAmount);
-		}
+            // Line Items
+            Assert.AreEqual("1", rates.Breakdown.LineItems[0].Id);
+            Assert.AreEqual(50, rates.Breakdown.LineItems[0].TaxableAmount);
+            Assert.AreEqual(4.44, rates.Breakdown.LineItems[0].TaxCollectable);
+            Assert.AreEqual(0.10875, rates.Breakdown.LineItems[0].CombinedTaxRate);
+            Assert.AreEqual(50, rates.Breakdown.LineItems[0].StateTaxableAmount);
+            Assert.AreEqual(0.04, rates.Breakdown.LineItems[0].StateSalesTaxRate);
+            Assert.AreEqual(2, rates.Breakdown.LineItems[0].StateAmount);
+            Assert.AreEqual(50, rates.Breakdown.LineItems[0].CountyTaxableAmount);
+            Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].CountyTaxRate);
+            Assert.AreEqual(0.5, rates.Breakdown.LineItems[0].CountyAmount);
+            Assert.AreEqual(50, rates.Breakdown.LineItems[0].CityTaxableAmount);
+            Assert.AreEqual(0.04875, rates.Breakdown.LineItems[0].CityTaxRate);
+            Assert.AreEqual(2.44, rates.Breakdown.LineItems[0].CityAmount);
+            Assert.AreEqual(50, rates.Breakdown.LineItems[0].SpecialDistrictTaxableAmount);
+            Assert.AreEqual(0.01, rates.Breakdown.LineItems[0].SpecialTaxRate);
+            Assert.AreEqual(0.5, rates.Breakdown.LineItems[0].SpecialDistrictAmount);
+        }
 
         [Test]
         public async Task when_calculating_sales_tax_for_an_order_async()
@@ -224,8 +224,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_calculating_sales_tax_for_an_international_order()
-		{
+        public void when_calculating_sales_tax_for_an_international_order()
+        {
             var body = JsonConvert.DeserializeObject<TaxResponse>(TaxjarFixture.GetJSON("taxes_international.json"));
 
             Bootstrap.server.Given(
@@ -239,61 +239,61 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var rates = Bootstrap.client.TaxForOrder(new
-			{
-				from_country = "FI",
-				from_zip = "00150",
-				to_country = "FI",
-				to_zip = "00150",
-				amount = 16.95,
-				shipping = 10,
-				exemption_type = "non_exempt",
-				line_items = new[] {
-					new
-					{
-						quantity = 1,
-						unit_price = 16.95
-					}
-				}
-			});
+            var rates = Bootstrap.client.TaxForOrder(new
+            {
+                from_country = "FI",
+                from_zip = "00150",
+                to_country = "FI",
+                to_zip = "00150",
+                amount = 16.95,
+                shipping = 10,
+                exemption_type = "non_exempt",
+                line_items = new[] {
+                    new
+                    {
+                        quantity = 1,
+                        unit_price = 16.95
+                    }
+                }
+            });
 
-			Assert.AreEqual(26.95, rates.OrderTotalAmount);
-			Assert.AreEqual(6.47, rates.AmountToCollect);
-			Assert.AreEqual(true, rates.HasNexus);
-			Assert.AreEqual(true, rates.FreightTaxable);
-			Assert.AreEqual("destination", rates.TaxSource);
-			Assert.AreEqual("non_exempt", rates.ExemptionType);
+            Assert.AreEqual(26.95, rates.OrderTotalAmount);
+            Assert.AreEqual(6.47, rates.AmountToCollect);
+            Assert.AreEqual(true, rates.HasNexus);
+            Assert.AreEqual(true, rates.FreightTaxable);
+            Assert.AreEqual("destination", rates.TaxSource);
+            Assert.AreEqual("non_exempt", rates.ExemptionType);
 
             // Jurisdictions
             Assert.AreEqual("FI", rates.Jurisdictions.Country);
 
             // Breakdowns
             Assert.AreEqual(26.95, rates.Breakdown.TaxableAmount);
-			Assert.AreEqual(6.47, rates.Breakdown.TaxCollectable);
-			Assert.AreEqual(0.24, rates.Breakdown.CombinedTaxRate);
-			Assert.AreEqual(26.95, rates.Breakdown.CountryTaxableAmount);
-			Assert.AreEqual(0.24, rates.Breakdown.CountryTaxRate);
-			Assert.AreEqual(6.47, rates.Breakdown.CountryTaxCollectable);
+            Assert.AreEqual(6.47, rates.Breakdown.TaxCollectable);
+            Assert.AreEqual(0.24, rates.Breakdown.CombinedTaxRate);
+            Assert.AreEqual(26.95, rates.Breakdown.CountryTaxableAmount);
+            Assert.AreEqual(0.24, rates.Breakdown.CountryTaxRate);
+            Assert.AreEqual(6.47, rates.Breakdown.CountryTaxCollectable);
 
-			Assert.AreEqual(10, rates.Breakdown.Shipping.TaxableAmount);
-			Assert.AreEqual(2.4, rates.Breakdown.Shipping.TaxCollectable);
-			Assert.AreEqual(0.24, rates.Breakdown.Shipping.CombinedTaxRate);
-			Assert.AreEqual(10, rates.Breakdown.Shipping.CountryTaxableAmount);
-			Assert.AreEqual(0.24, rates.Breakdown.Shipping.CountryTaxRate);
-			Assert.AreEqual(2.4, rates.Breakdown.Shipping.CountryTaxCollectable);
+            Assert.AreEqual(10, rates.Breakdown.Shipping.TaxableAmount);
+            Assert.AreEqual(2.4, rates.Breakdown.Shipping.TaxCollectable);
+            Assert.AreEqual(0.24, rates.Breakdown.Shipping.CombinedTaxRate);
+            Assert.AreEqual(10, rates.Breakdown.Shipping.CountryTaxableAmount);
+            Assert.AreEqual(0.24, rates.Breakdown.Shipping.CountryTaxRate);
+            Assert.AreEqual(2.4, rates.Breakdown.Shipping.CountryTaxCollectable);
 
-			// Line Items
-			Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].TaxableAmount);
-			Assert.AreEqual(4.07, rates.Breakdown.LineItems[0].TaxCollectable);
-			Assert.AreEqual(0.24, rates.Breakdown.LineItems[0].CombinedTaxRate);
-			Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].CountryTaxableAmount);
-			Assert.AreEqual(0.24, rates.Breakdown.LineItems[0].CountryTaxRate);
-			Assert.AreEqual(4.07, rates.Breakdown.LineItems[0].CountryTaxCollectable);
-		}
+            // Line Items
+            Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].TaxableAmount);
+            Assert.AreEqual(4.07, rates.Breakdown.LineItems[0].TaxCollectable);
+            Assert.AreEqual(0.24, rates.Breakdown.LineItems[0].CombinedTaxRate);
+            Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].CountryTaxableAmount);
+            Assert.AreEqual(0.24, rates.Breakdown.LineItems[0].CountryTaxRate);
+            Assert.AreEqual(4.07, rates.Breakdown.LineItems[0].CountryTaxCollectable);
+        }
 
-		[Test]
-		public void when_calculating_sales_tax_for_a_canadian_order()
-		{
+        [Test]
+        public void when_calculating_sales_tax_for_a_canadian_order()
+        {
             var body = JsonConvert.DeserializeObject<TaxResponse>(TaxjarFixture.GetJSON("taxes_canada.json"));
 
             Bootstrap.server.Given(
@@ -307,35 +307,35 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var rates = Bootstrap.client.TaxForOrder(new
-			{
-				from_country = "CA",
-				from_zip = "V6G 3E",
-				from_state = "BC",
-				to_country = "CA",
-				to_zip = "M5V 2T6",
-				to_state = "ON",
-				amount = 16.95,
-				shipping = 10,
-				exemption_type = "non_exempt",
-				line_items = new[] {
-					new
-					{
-						quantity = 1,
-						unit_price = 16.95
-					}
-				}
-			});
+            var rates = Bootstrap.client.TaxForOrder(new
+            {
+                from_country = "CA",
+                from_zip = "V6G 3E",
+                from_state = "BC",
+                to_country = "CA",
+                to_zip = "M5V 2T6",
+                to_state = "ON",
+                amount = 16.95,
+                shipping = 10,
+                exemption_type = "non_exempt",
+                line_items = new[] {
+                    new
+                    {
+                        quantity = 1,
+                        unit_price = 16.95
+                    }
+                }
+            });
 
-			Assert.AreEqual(26.95, rates.OrderTotalAmount);
-			Assert.AreEqual(10, rates.Shipping);
-			Assert.AreEqual(26.95, rates.TaxableAmount);
-			Assert.AreEqual(3.5, rates.AmountToCollect);
-			Assert.AreEqual(0.13, rates.Rate);
-			Assert.AreEqual(true, rates.HasNexus);
-			Assert.AreEqual(true, rates.FreightTaxable);
-			Assert.AreEqual("destination", rates.TaxSource);
-			Assert.AreEqual("non_exempt", rates.ExemptionType);
+            Assert.AreEqual(26.95, rates.OrderTotalAmount);
+            Assert.AreEqual(10, rates.Shipping);
+            Assert.AreEqual(26.95, rates.TaxableAmount);
+            Assert.AreEqual(3.5, rates.AmountToCollect);
+            Assert.AreEqual(0.13, rates.Rate);
+            Assert.AreEqual(true, rates.HasNexus);
+            Assert.AreEqual(true, rates.FreightTaxable);
+            Assert.AreEqual("destination", rates.TaxSource);
+            Assert.AreEqual("non_exempt", rates.ExemptionType);
 
             // Jurisdictions
             Assert.AreEqual("CA", rates.Jurisdictions.Country);
@@ -343,44 +343,44 @@ namespace Taxjar.Tests
 
             // Breakdowns
             Assert.AreEqual(26.95, rates.Breakdown.TaxableAmount);
-			Assert.AreEqual(3.5, rates.Breakdown.TaxCollectable);
-			Assert.AreEqual(0.13, rates.Breakdown.CombinedTaxRate);
-			Assert.AreEqual(26.95, rates.Breakdown.GSTTaxableAmount);
-			Assert.AreEqual(0.05, rates.Breakdown.GSTTaxRate);
-			Assert.AreEqual(1.35, rates.Breakdown.GST);
-			Assert.AreEqual(26.95, rates.Breakdown.PSTTaxableAmount);
-			Assert.AreEqual(0.08, rates.Breakdown.PSTTaxRate);
-			Assert.AreEqual(2.16, rates.Breakdown.PST);
-			Assert.AreEqual(0, rates.Breakdown.QSTTaxableAmount);
-			Assert.AreEqual(0, rates.Breakdown.QSTTaxRate);
-			Assert.AreEqual(0, rates.Breakdown.QST);
+            Assert.AreEqual(3.5, rates.Breakdown.TaxCollectable);
+            Assert.AreEqual(0.13, rates.Breakdown.CombinedTaxRate);
+            Assert.AreEqual(26.95, rates.Breakdown.GSTTaxableAmount);
+            Assert.AreEqual(0.05, rates.Breakdown.GSTTaxRate);
+            Assert.AreEqual(1.35, rates.Breakdown.GST);
+            Assert.AreEqual(26.95, rates.Breakdown.PSTTaxableAmount);
+            Assert.AreEqual(0.08, rates.Breakdown.PSTTaxRate);
+            Assert.AreEqual(2.16, rates.Breakdown.PST);
+            Assert.AreEqual(0, rates.Breakdown.QSTTaxableAmount);
+            Assert.AreEqual(0, rates.Breakdown.QSTTaxRate);
+            Assert.AreEqual(0, rates.Breakdown.QST);
 
-			Assert.AreEqual(10, rates.Breakdown.Shipping.TaxableAmount);
-			Assert.AreEqual(1.3, rates.Breakdown.Shipping.TaxCollectable);
-			Assert.AreEqual(0.13, rates.Breakdown.Shipping.CombinedTaxRate);
-			Assert.AreEqual(10, rates.Breakdown.Shipping.GSTTaxableAmount);
-			Assert.AreEqual(0.05, rates.Breakdown.Shipping.GSTTaxRate);
-			Assert.AreEqual(0.5, rates.Breakdown.Shipping.GST);
-			Assert.AreEqual(10, rates.Breakdown.Shipping.PSTTaxableAmount);
-			Assert.AreEqual(0.08, rates.Breakdown.Shipping.PSTTaxRate);
-			Assert.AreEqual(0.8, rates.Breakdown.Shipping.PST);
-			Assert.AreEqual(0, rates.Breakdown.Shipping.QSTTaxableAmount);
-			Assert.AreEqual(0, rates.Breakdown.Shipping.QSTTaxRate);
-			Assert.AreEqual(0, rates.Breakdown.Shipping.QST);
+            Assert.AreEqual(10, rates.Breakdown.Shipping.TaxableAmount);
+            Assert.AreEqual(1.3, rates.Breakdown.Shipping.TaxCollectable);
+            Assert.AreEqual(0.13, rates.Breakdown.Shipping.CombinedTaxRate);
+            Assert.AreEqual(10, rates.Breakdown.Shipping.GSTTaxableAmount);
+            Assert.AreEqual(0.05, rates.Breakdown.Shipping.GSTTaxRate);
+            Assert.AreEqual(0.5, rates.Breakdown.Shipping.GST);
+            Assert.AreEqual(10, rates.Breakdown.Shipping.PSTTaxableAmount);
+            Assert.AreEqual(0.08, rates.Breakdown.Shipping.PSTTaxRate);
+            Assert.AreEqual(0.8, rates.Breakdown.Shipping.PST);
+            Assert.AreEqual(0, rates.Breakdown.Shipping.QSTTaxableAmount);
+            Assert.AreEqual(0, rates.Breakdown.Shipping.QSTTaxRate);
+            Assert.AreEqual(0, rates.Breakdown.Shipping.QST);
 
-			// Line Items
-			Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].TaxableAmount);
-			Assert.AreEqual(2.2, rates.Breakdown.LineItems[0].TaxCollectable);
-			Assert.AreEqual(0.13, rates.Breakdown.LineItems[0].CombinedTaxRate);
-			Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].GSTTaxableAmount);
-			Assert.AreEqual(0.05, rates.Breakdown.LineItems[0].GSTTaxRate);
-			Assert.AreEqual(0.85, rates.Breakdown.LineItems[0].GST);
-			Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].PSTTaxableAmount);
-			Assert.AreEqual(0.08, rates.Breakdown.LineItems[0].PSTTaxRate);
-			Assert.AreEqual(1.36, rates.Breakdown.LineItems[0].PST);
-			Assert.AreEqual(0, rates.Breakdown.LineItems[0].QSTTaxableAmount);
-			Assert.AreEqual(0, rates.Breakdown.LineItems[0].QSTTaxRate);
-			Assert.AreEqual(0, rates.Breakdown.LineItems[0].QST);
-		}
-	}
+            // Line Items
+            Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].TaxableAmount);
+            Assert.AreEqual(2.2, rates.Breakdown.LineItems[0].TaxCollectable);
+            Assert.AreEqual(0.13, rates.Breakdown.LineItems[0].CombinedTaxRate);
+            Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].GSTTaxableAmount);
+            Assert.AreEqual(0.05, rates.Breakdown.LineItems[0].GSTTaxRate);
+            Assert.AreEqual(0.85, rates.Breakdown.LineItems[0].GST);
+            Assert.AreEqual(16.95, rates.Breakdown.LineItems[0].PSTTaxableAmount);
+            Assert.AreEqual(0.08, rates.Breakdown.LineItems[0].PSTTaxRate);
+            Assert.AreEqual(1.36, rates.Breakdown.LineItems[0].PST);
+            Assert.AreEqual(0, rates.Breakdown.LineItems[0].QSTTaxableAmount);
+            Assert.AreEqual(0, rates.Breakdown.LineItems[0].QSTTaxRate);
+            Assert.AreEqual(0, rates.Breakdown.LineItems[0].QST);
+        }
+    }
 }

--- a/src/Taxjar.Tests/Transactions.cs
+++ b/src/Taxjar.Tests/Transactions.cs
@@ -8,9 +8,9 @@ using WireMock.ResponseBuilders;
 
 namespace Taxjar.Tests
 {
-	[TestFixture]
-	public class TransactionsTests
-	{
+    [TestFixture]
+    public class TransactionsTests
+    {
         [SetUp]
         public void Init()
         {
@@ -18,82 +18,82 @@ namespace Taxjar.Tests
             Bootstrap.server.ResetMappings();
         }
 
-		public void AssertOrder(OrderResponseAttributes order)
-		{
-			Assert.AreEqual("123", order.TransactionId);
-			Assert.AreEqual(10649, order.UserId);
-			Assert.AreEqual("2015-05-14T00:00:00Z", order.TransactionDate);
-			Assert.AreEqual("api", order.Provider);
-			Assert.AreEqual("non_exempt", order.ExemptionType);
-			Assert.AreEqual("US", order.ToCountry);
-			Assert.AreEqual("90002", order.ToZip);
-			Assert.AreEqual("CA", order.ToState);
-			Assert.AreEqual("LOS ANGELES", order.ToCity);
-			Assert.AreEqual("123 Palm Grove Ln", order.ToStreet);
-			Assert.AreEqual(17.95, order.Amount);
-			Assert.AreEqual(2, order.Shipping);
-			Assert.AreEqual(0.95, order.SalesTax);
-			Assert.AreEqual("1", order.LineItems[0].Id);
-			Assert.AreEqual(1, order.LineItems[0].Quantity);
-			Assert.AreEqual("12-34243-0", order.LineItems[0].ProductIdentifier);
-			Assert.AreEqual("Heavy Widget", order.LineItems[0].Description);
-			Assert.AreEqual("20010", order.LineItems[0].ProductTaxCode);
-			Assert.AreEqual(15, order.LineItems[0].UnitPrice);
-			Assert.AreEqual(0, order.LineItems[0].Discount);
-			Assert.AreEqual(0.95, order.LineItems[0].SalesTax);
-		}
+        public void AssertOrder(OrderResponseAttributes order)
+        {
+            Assert.AreEqual("123", order.TransactionId);
+            Assert.AreEqual(10649, order.UserId);
+            Assert.AreEqual("2015-05-14T00:00:00Z", order.TransactionDate);
+            Assert.AreEqual("api", order.Provider);
+            Assert.AreEqual("non_exempt", order.ExemptionType);
+            Assert.AreEqual("US", order.ToCountry);
+            Assert.AreEqual("90002", order.ToZip);
+            Assert.AreEqual("CA", order.ToState);
+            Assert.AreEqual("LOS ANGELES", order.ToCity);
+            Assert.AreEqual("123 Palm Grove Ln", order.ToStreet);
+            Assert.AreEqual(17.95, order.Amount);
+            Assert.AreEqual(2, order.Shipping);
+            Assert.AreEqual(0.95, order.SalesTax);
+            Assert.AreEqual("1", order.LineItems[0].Id);
+            Assert.AreEqual(1, order.LineItems[0].Quantity);
+            Assert.AreEqual("12-34243-0", order.LineItems[0].ProductIdentifier);
+            Assert.AreEqual("Heavy Widget", order.LineItems[0].Description);
+            Assert.AreEqual("20010", order.LineItems[0].ProductTaxCode);
+            Assert.AreEqual(15, order.LineItems[0].UnitPrice);
+            Assert.AreEqual(0, order.LineItems[0].Discount);
+            Assert.AreEqual(0.95, order.LineItems[0].SalesTax);
+        }
 
         public void AssertDeletedOrder(OrderResponseAttributes order)
-		{
-			Assert.AreEqual("123", order.TransactionId);
-			Assert.AreEqual(null, order.TransactionDate);
-			Assert.AreEqual("api", order.Provider);
-			Assert.AreEqual(null, order.ExemptionType);
-			Assert.AreEqual(0, order.Amount);
-			Assert.AreEqual(0, order.Shipping);
-			Assert.AreEqual(0, order.SalesTax);
-		}
+        {
+            Assert.AreEqual("123", order.TransactionId);
+            Assert.AreEqual(null, order.TransactionDate);
+            Assert.AreEqual("api", order.Provider);
+            Assert.AreEqual(null, order.ExemptionType);
+            Assert.AreEqual(0, order.Amount);
+            Assert.AreEqual(0, order.Shipping);
+            Assert.AreEqual(0, order.SalesTax);
+        }
 
-		public void AssertRefund(RefundResponseAttributes refund)
-		{
-			Assert.AreEqual("321", refund.TransactionId);
-			Assert.AreEqual("123", refund.TransactionReferenceId);
-			Assert.AreEqual(10649, refund.UserId);
-			Assert.AreEqual("2015-05-14T00:00:00Z", refund.TransactionDate);
-			Assert.AreEqual("api", refund.Provider);
-			Assert.AreEqual("non_exempt", refund.ExemptionType);
-			Assert.AreEqual("US", refund.ToCountry);
-			Assert.AreEqual("90002", refund.ToZip);
-			Assert.AreEqual("CA", refund.ToState);
-			Assert.AreEqual("LOS ANGELES", refund.ToCity);
-			Assert.AreEqual("123 Palm Grove Ln", refund.ToStreet);
-			Assert.AreEqual(17.95, refund.Amount);
-			Assert.AreEqual(2, refund.Shipping);
-			Assert.AreEqual(0.95, refund.SalesTax);
-			Assert.AreEqual("1", refund.LineItems[0].Id);
-			Assert.AreEqual(1, refund.LineItems[0].Quantity);
-			Assert.AreEqual("12-34243-0", refund.LineItems[0].ProductIdentifier);
-			Assert.AreEqual("Heavy Widget", refund.LineItems[0].Description);
-			Assert.AreEqual("20010", refund.LineItems[0].ProductTaxCode);
-			Assert.AreEqual(15, refund.LineItems[0].UnitPrice);
-			Assert.AreEqual(0, refund.LineItems[0].Discount);
-			Assert.AreEqual(0.95, refund.LineItems[0].SalesTax);
-		}
+        public void AssertRefund(RefundResponseAttributes refund)
+        {
+            Assert.AreEqual("321", refund.TransactionId);
+            Assert.AreEqual("123", refund.TransactionReferenceId);
+            Assert.AreEqual(10649, refund.UserId);
+            Assert.AreEqual("2015-05-14T00:00:00Z", refund.TransactionDate);
+            Assert.AreEqual("api", refund.Provider);
+            Assert.AreEqual("non_exempt", refund.ExemptionType);
+            Assert.AreEqual("US", refund.ToCountry);
+            Assert.AreEqual("90002", refund.ToZip);
+            Assert.AreEqual("CA", refund.ToState);
+            Assert.AreEqual("LOS ANGELES", refund.ToCity);
+            Assert.AreEqual("123 Palm Grove Ln", refund.ToStreet);
+            Assert.AreEqual(17.95, refund.Amount);
+            Assert.AreEqual(2, refund.Shipping);
+            Assert.AreEqual(0.95, refund.SalesTax);
+            Assert.AreEqual("1", refund.LineItems[0].Id);
+            Assert.AreEqual(1, refund.LineItems[0].Quantity);
+            Assert.AreEqual("12-34243-0", refund.LineItems[0].ProductIdentifier);
+            Assert.AreEqual("Heavy Widget", refund.LineItems[0].Description);
+            Assert.AreEqual("20010", refund.LineItems[0].ProductTaxCode);
+            Assert.AreEqual(15, refund.LineItems[0].UnitPrice);
+            Assert.AreEqual(0, refund.LineItems[0].Discount);
+            Assert.AreEqual(0.95, refund.LineItems[0].SalesTax);
+        }
 
         public void AssertDeletedRefund(RefundResponseAttributes refund)
-		{
-			Assert.AreEqual("321", refund.TransactionId);
-			Assert.AreEqual(null, refund.TransactionDate);
-			Assert.AreEqual("api", refund.Provider);
-			Assert.AreEqual(null, refund.ExemptionType);
-			Assert.AreEqual(0, refund.Amount);
-			Assert.AreEqual(0, refund.Shipping);
-			Assert.AreEqual(0, refund.SalesTax);
-		}
+        {
+            Assert.AreEqual("321", refund.TransactionId);
+            Assert.AreEqual(null, refund.TransactionDate);
+            Assert.AreEqual("api", refund.Provider);
+            Assert.AreEqual(null, refund.ExemptionType);
+            Assert.AreEqual(0, refund.Amount);
+            Assert.AreEqual(0, refund.Shipping);
+            Assert.AreEqual(0, refund.SalesTax);
+        }
 
-		[Test]
-		public void when_listing_order_transactions()
-		{
+        [Test]
+        public void when_listing_order_transactions()
+        {
             var body = JsonConvert.DeserializeObject<OrdersResponse>(TaxjarFixture.GetJSON("orders/list.json"));
 
             Bootstrap.server.Given(
@@ -107,15 +107,15 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var orders = Bootstrap.client.ListOrders(new {
-				from_transaction_date = "2015/05/01",
-				to_transaction_date = "2015/05/31",
-				provider = "api"
-			});
+            var orders = Bootstrap.client.ListOrders(new {
+                from_transaction_date = "2015/05/01",
+                to_transaction_date = "2015/05/31",
+                provider = "api"
+            });
 
-			Assert.AreEqual("123", orders[0]);
-			Assert.AreEqual("456", orders[1]);
-		}
+            Assert.AreEqual("123", orders[0]);
+            Assert.AreEqual("456", orders[1]);
+        }
 
         [Test]
         public async Task when_listing_order_transactions_async()
@@ -145,8 +145,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_showing_an_order_transaction()
-		{
+        public void when_showing_an_order_transaction()
+        {
             var body = JsonConvert.DeserializeObject<OrderResponse>(TaxjarFixture.GetJSON("orders/show.json"));
 
             Bootstrap.server.Given(
@@ -160,11 +160,11 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var order = Bootstrap.client.ShowOrder("123", new {
-				provider = "api"
-			});
-			AssertOrder(order);
-		}
+            var order = Bootstrap.client.ShowOrder("123", new {
+                provider = "api"
+            });
+            AssertOrder(order);
+        }
 
         [Test]
         public async Task when_showing_an_order_transaction_async()
@@ -190,8 +190,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_creating_an_order_transaction()
-		{
+        public void when_creating_an_order_transaction()
+        {
             var body = JsonConvert.DeserializeObject<OrderResponse>(TaxjarFixture.GetJSON("orders/show.json"));
 
             Bootstrap.server.Given(
@@ -205,32 +205,32 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var order = Bootstrap.client.CreateOrder(new {
-				transaction_id = "123",
-				transaction_date = "2015/05/04",
-				provider = "api",
-				exemption_type = "non_exempt",
-				to_country = "US",
-				to_zip = "90002",
-				to_city = "Los Angeles",
-				to_street = "123 Palm Grove Ln",
-				amount = 17.95,
-				shipping = 2,
-				sales_tax = 0.95,
-				line_items = new[] {
-					new {
-						quantity = 1,
-						product_identifier = "12-34243-0",
-						description = "Heavy Widget",
-						product_tax_code = "20010",
-						unit_price = 15,
-						sales_tax = 0.95
-					}
-				}
-			});
+            var order = Bootstrap.client.CreateOrder(new {
+                transaction_id = "123",
+                transaction_date = "2015/05/04",
+                provider = "api",
+                exemption_type = "non_exempt",
+                to_country = "US",
+                to_zip = "90002",
+                to_city = "Los Angeles",
+                to_street = "123 Palm Grove Ln",
+                amount = 17.95,
+                shipping = 2,
+                sales_tax = 0.95,
+                line_items = new[] {
+                    new {
+                        quantity = 1,
+                        product_identifier = "12-34243-0",
+                        description = "Heavy Widget",
+                        product_tax_code = "20010",
+                        unit_price = 15,
+                        sales_tax = 0.95
+                    }
+                }
+            });
 
-			AssertOrder(order);
-		}
+            AssertOrder(order);
+        }
 
         [Test]
         public async Task when_creating_an_order_transaction_async()
@@ -277,8 +277,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_updating_an_order_transaction()
-		{
+        public void when_updating_an_order_transaction()
+        {
             var body = JsonConvert.DeserializeObject<OrderResponse>(TaxjarFixture.GetJSON("orders/show.json"));
 
             Bootstrap.server.Given(
@@ -292,27 +292,27 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var order = Bootstrap.client.UpdateOrder(new
-			{
-				transaction_id = "123",
-				amount = 17.95,
-				shipping = 2,
-				exemption_type = "non_exempt",
-				line_items = new[] {
-					new {
-						quantity = 1,
-						product_identifier = "12-34243-0",
-						description = "Heavy Widget",
-						product_tax_code = "20010",
-						unit_price = 15,
-						discount = 0,
-						sales_tax = 0.95
-					}
-				}
-			});
+            var order = Bootstrap.client.UpdateOrder(new
+            {
+                transaction_id = "123",
+                amount = 17.95,
+                shipping = 2,
+                exemption_type = "non_exempt",
+                line_items = new[] {
+                    new {
+                        quantity = 1,
+                        product_identifier = "12-34243-0",
+                        description = "Heavy Widget",
+                        product_tax_code = "20010",
+                        unit_price = 15,
+                        discount = 0,
+                        sales_tax = 0.95
+                    }
+                }
+            });
 
-			AssertOrder(order);
-		}
+            AssertOrder(order);
+        }
 
         [Test]
         public async Task when_updating_an_order_transaction_async()
@@ -389,8 +389,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_deleting_an_order_transaction()
-		{
+        public void when_deleting_an_order_transaction()
+        {
             var body = JsonConvert.DeserializeObject<OrderResponse>(TaxjarFixture.GetJSON("orders/delete.json"));
 
             Bootstrap.server.Given(
@@ -404,11 +404,11 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var order = Bootstrap.client.DeleteOrder("123", new {
-				provider = "api"
-			});
-			AssertDeletedOrder(order);
-		}
+            var order = Bootstrap.client.DeleteOrder("123", new {
+                provider = "api"
+            });
+            AssertDeletedOrder(order);
+        }
 
         [Test]
         public async Task when_deleting_an_order_transaction_async()
@@ -433,8 +433,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_listing_refund_transactions()
-		{
+        public void when_listing_refund_transactions()
+        {
             var body = JsonConvert.DeserializeObject<RefundsResponse>(TaxjarFixture.GetJSON("refunds/list.json"));
 
             Bootstrap.server.Given(
@@ -448,16 +448,16 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var refunds = Bootstrap.client.ListRefunds(new
-			{
-				from_transaction_date = "2015/05/01",
-				to_transaction_date = "2015/05/31",
-				provider = "api"
-			});
+            var refunds = Bootstrap.client.ListRefunds(new
+            {
+                from_transaction_date = "2015/05/01",
+                to_transaction_date = "2015/05/31",
+                provider = "api"
+            });
 
-			Assert.AreEqual("321", refunds[0]);
-			Assert.AreEqual("654", refunds[1]);
-		}
+            Assert.AreEqual("321", refunds[0]);
+            Assert.AreEqual("654", refunds[1]);
+        }
 
         [Test]
         public async Task when_listing_refund_transactions_async()
@@ -487,8 +487,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_showing_a_refund_transaction()
-		{
+        public void when_showing_a_refund_transaction()
+        {
             var body = JsonConvert.DeserializeObject<RefundResponse>(TaxjarFixture.GetJSON("refunds/show.json"));
 
             Bootstrap.server.Given(
@@ -502,11 +502,11 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var refund = Bootstrap.client.ShowRefund("321", new {
-				provider = "api"
-			});
-			AssertRefund(refund);
-		}
+            var refund = Bootstrap.client.ShowRefund("321", new {
+                provider = "api"
+            });
+            AssertRefund(refund);
+        }
 
         [Test]
         public async Task when_showing_a_refund_transaction_async()
@@ -531,8 +531,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_creating_a_refund_transaction()
-		{
+        public void when_creating_a_refund_transaction()
+        {
             var body = JsonConvert.DeserializeObject<RefundResponse>(TaxjarFixture.GetJSON("refunds/show.json"));
 
             Bootstrap.server.Given(
@@ -546,34 +546,34 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var refund = Bootstrap.client.CreateRefund(new
-			{
-				transaction_id = "321",
-				transaction_date = "2015/05/04",
-				transaction_reference_id = "123",
-				provider = "api",
-				exemption_type = "non_exempt",
-				to_country = "US",
-				to_zip = "90002",
-				to_city = "Los Angeles",
-				to_street = "123 Palm Grove Ln",
-				amount = 17.95,
-				shipping = 2,
-				sales_tax = 0.95,
-				line_items = new[] {
-					new {
-						quantity = 1,
-						product_identifier = "12-34243-0",
-						description = "Heavy Widget",
-						product_tax_code = "20010",
-						unit_price = 15,
-						sales_tax = 0.95
-					}
-				}
-			});
+            var refund = Bootstrap.client.CreateRefund(new
+            {
+                transaction_id = "321",
+                transaction_date = "2015/05/04",
+                transaction_reference_id = "123",
+                provider = "api",
+                exemption_type = "non_exempt",
+                to_country = "US",
+                to_zip = "90002",
+                to_city = "Los Angeles",
+                to_street = "123 Palm Grove Ln",
+                amount = 17.95,
+                shipping = 2,
+                sales_tax = 0.95,
+                line_items = new[] {
+                    new {
+                        quantity = 1,
+                        product_identifier = "12-34243-0",
+                        description = "Heavy Widget",
+                        product_tax_code = "20010",
+                        unit_price = 15,
+                        sales_tax = 0.95
+                    }
+                }
+            });
 
-			AssertRefund(refund);
-		}
+            AssertRefund(refund);
+        }
 
         [Test]
         public async Task when_creating_a_refund_transaction_async()
@@ -621,8 +621,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_updating_a_refund_transaction()
-		{
+        public void when_updating_a_refund_transaction()
+        {
             var body = JsonConvert.DeserializeObject<RefundResponse>(TaxjarFixture.GetJSON("refunds/show.json"));
 
             Bootstrap.server.Given(
@@ -636,27 +636,27 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var refund = Bootstrap.client.UpdateRefund(new
-			{
-				transaction_id = "321",
-				amount = 17.95,
-				shipping = 2,
-				exemption_type = "non_exempt",
-				line_items = new[] {
-					new {
-						quantity = 1,
-						product_identifier = "12-34243-0",
-						description = "Heavy Widget",
-						product_tax_code = "20010",
-						unit_price = 15,
-						discount = 0,
-						sales_tax = 0.95
-					}
-				}
-			});
+            var refund = Bootstrap.client.UpdateRefund(new
+            {
+                transaction_id = "321",
+                amount = 17.95,
+                shipping = 2,
+                exemption_type = "non_exempt",
+                line_items = new[] {
+                    new {
+                        quantity = 1,
+                        product_identifier = "12-34243-0",
+                        description = "Heavy Widget",
+                        product_tax_code = "20010",
+                        unit_price = 15,
+                        discount = 0,
+                        sales_tax = 0.95
+                    }
+                }
+            });
 
-			AssertRefund(refund);
-		}
+            AssertRefund(refund);
+        }
 
         [Test]
         public async Task when_updating_a_refund_transaction_async()
@@ -733,8 +733,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_deleting_a_refund_transaction()
-		{
+        public void when_deleting_a_refund_transaction()
+        {
             var body = JsonConvert.DeserializeObject<RefundResponse>(TaxjarFixture.GetJSON("refunds/delete.json"));
 
             Bootstrap.server.Given(
@@ -748,11 +748,11 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-			var refund = Bootstrap.client.DeleteRefund("321", new {
-				provider = "api"
-			});
-			AssertDeletedRefund(refund);
-		}
+            var refund = Bootstrap.client.DeleteRefund("321", new {
+                provider = "api"
+            });
+            AssertDeletedRefund(refund);
+        }
 
         [Test]
         public async Task when_deleting_a_refund_transaction_async()

--- a/src/Taxjar.Tests/Validations.cs
+++ b/src/Taxjar.Tests/Validations.cs
@@ -6,9 +6,9 @@ using WireMock.ResponseBuilders;
 
 namespace Taxjar.Tests
 {
-	[TestFixture]
-	public class ValidationTests
-	{
+    [TestFixture]
+    public class ValidationTests
+    {
         [SetUp]
         public static void Init()
         {
@@ -117,8 +117,8 @@ namespace Taxjar.Tests
         }
 
         [Test]
-		public void when_validating_a_vat_number()
-		{
+        public void when_validating_a_vat_number()
+        {
             var body = JsonConvert.DeserializeObject<ValidationResponse>(TaxjarFixture.GetJSON("validation.json"));
 
             Bootstrap.server.Given(
@@ -133,19 +133,19 @@ namespace Taxjar.Tests
             );
 
             var validation = Bootstrap.client.ValidateVat(new {
-				vat = "FR40303265045"
-			});
+                vat = "FR40303265045"
+            });
 
-			Assert.AreEqual(true, validation.Valid);
-			Assert.AreEqual(true, validation.Exists);
-			Assert.AreEqual(true, validation.ViesAvailable);
-			Assert.AreEqual("FR", validation.ViesResponse.CountryCode);
-			Assert.AreEqual("40303265045", validation.ViesResponse.VatNumber);
-			Assert.AreEqual("2016-02-10", validation.ViesResponse.RequestDate);
-			Assert.AreEqual(true, validation.ViesResponse.Valid);
-			Assert.AreEqual("SA SODIMAS", validation.ViesResponse.Name);
-			Assert.AreEqual("11 RUE AMPEREn26600 PONT DE L ISERE", validation.ViesResponse.Address);
-		}
+            Assert.AreEqual(true, validation.Valid);
+            Assert.AreEqual(true, validation.Exists);
+            Assert.AreEqual(true, validation.ViesAvailable);
+            Assert.AreEqual("FR", validation.ViesResponse.CountryCode);
+            Assert.AreEqual("40303265045", validation.ViesResponse.VatNumber);
+            Assert.AreEqual("2016-02-10", validation.ViesResponse.RequestDate);
+            Assert.AreEqual(true, validation.ViesResponse.Valid);
+            Assert.AreEqual("SA SODIMAS", validation.ViesResponse.Name);
+            Assert.AreEqual("11 RUE AMPEREn26600 PONT DE L ISERE", validation.ViesResponse.Address);
+        }
 
         [Test]
         public async Task when_validating_a_vat_number_async()

--- a/src/Taxjar/Entities/TaxjarBreakdown.cs
+++ b/src/Taxjar/Entities/TaxjarBreakdown.cs
@@ -4,66 +4,66 @@ namespace Taxjar
 {
     public class Breakdown
     {
-		[JsonProperty("taxable_amount")]
-		public decimal TaxableAmount { get; set; }
+        [JsonProperty("taxable_amount")]
+        public decimal TaxableAmount { get; set; }
 
-		[JsonProperty("tax_collectable")]
-		public decimal TaxCollectable { get; set; }
+        [JsonProperty("tax_collectable")]
+        public decimal TaxCollectable { get; set; }
 
-		[JsonProperty("combined_tax_rate")]
-		public decimal CombinedTaxRate { get; set; }
+        [JsonProperty("combined_tax_rate")]
+        public decimal CombinedTaxRate { get; set; }
 
-		[JsonProperty("state_taxable_amount")]
-		public decimal StateTaxableAmount { get; set; }
+        [JsonProperty("state_taxable_amount")]
+        public decimal StateTaxableAmount { get; set; }
 
-		[JsonProperty("county_taxable_amount")]
-		public decimal CountyTaxableAmount { get; set; }
+        [JsonProperty("county_taxable_amount")]
+        public decimal CountyTaxableAmount { get; set; }
 
-		[JsonProperty("county_tax_rate")]
-		public decimal CountyTaxRate { get; set; }
+        [JsonProperty("county_tax_rate")]
+        public decimal CountyTaxRate { get; set; }
 
-		[JsonProperty("city_taxable_amount")]
-		public decimal CityTaxableAmount { get; set; }
+        [JsonProperty("city_taxable_amount")]
+        public decimal CityTaxableAmount { get; set; }
 
-		[JsonProperty("city_tax_rate")]
-		public decimal CityTaxRate { get; set; }
+        [JsonProperty("city_tax_rate")]
+        public decimal CityTaxRate { get; set; }
 
-		// International
-		[JsonProperty("country_taxable_amount")]
-		public decimal CountryTaxableAmount { get; set; }
+        // International
+        [JsonProperty("country_taxable_amount")]
+        public decimal CountryTaxableAmount { get; set; }
 
-		[JsonProperty("country_tax_rate")]
-		public decimal CountryTaxRate { get; set; }
+        [JsonProperty("country_tax_rate")]
+        public decimal CountryTaxRate { get; set; }
 
-		[JsonProperty("country_tax_collectable")]
-		public decimal CountryTaxCollectable { get; set; }
+        [JsonProperty("country_tax_collectable")]
+        public decimal CountryTaxCollectable { get; set; }
 
-		// Canada
-		[JsonProperty("gst_taxable_amount")]
-		public decimal GSTTaxableAmount { get; set; }
+        // Canada
+        [JsonProperty("gst_taxable_amount")]
+        public decimal GSTTaxableAmount { get; set; }
 
-		[JsonProperty("gst_tax_rate")]
-		public decimal GSTTaxRate { get; set; }
+        [JsonProperty("gst_tax_rate")]
+        public decimal GSTTaxRate { get; set; }
 
-		[JsonProperty("gst")]
-		public decimal GST { get; set; }
+        [JsonProperty("gst")]
+        public decimal GST { get; set; }
 
-		[JsonProperty("pst_taxable_amount")]
-		public decimal PSTTaxableAmount { get; set; }
+        [JsonProperty("pst_taxable_amount")]
+        public decimal PSTTaxableAmount { get; set; }
 
-		[JsonProperty("pst_tax_rate")]
-		public decimal PSTTaxRate { get; set; }
+        [JsonProperty("pst_tax_rate")]
+        public decimal PSTTaxRate { get; set; }
 
-		[JsonProperty("pst")]
-		public decimal PST { get; set; }
+        [JsonProperty("pst")]
+        public decimal PST { get; set; }
 
-		[JsonProperty("qst_taxable_amount")]
-		public decimal QSTTaxableAmount { get; set; }
+        [JsonProperty("qst_taxable_amount")]
+        public decimal QSTTaxableAmount { get; set; }
 
-		[JsonProperty("qst_tax_rate")]
-		public decimal QSTTaxRate { get; set; }
+        [JsonProperty("qst_tax_rate")]
+        public decimal QSTTaxRate { get; set; }
 
-		[JsonProperty("qst")]
-		public decimal QST { get; set; }
+        [JsonProperty("qst")]
+        public decimal QST { get; set; }
     }
 }

--- a/src/Taxjar/Entities/TaxjarCategory.cs
+++ b/src/Taxjar/Entities/TaxjarCategory.cs
@@ -3,21 +3,21 @@ using Newtonsoft.Json;
 
 namespace Taxjar
 {
-	public class CategoriesResponse
-	{
-		[JsonProperty("categories")]
-		public List<Category> Categories { get; set; }
-	}
+    public class CategoriesResponse
+    {
+        [JsonProperty("categories")]
+        public List<Category> Categories { get; set; }
+    }
 
-	public class Category
-	{
-		[JsonProperty("name")]
-		public string Name { get; set; }
+    public class Category
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-		[JsonProperty("product_tax_code")]
-		public string ProductTaxCode { get; set; }
+        [JsonProperty("product_tax_code")]
+        public string ProductTaxCode { get; set; }
 
-		[JsonProperty("description")]
-		public string Description { get; set; }
-	}
+        [JsonProperty("description")]
+        public string Description { get; set; }
+    }
 }

--- a/src/Taxjar/Entities/TaxjarError.cs
+++ b/src/Taxjar/Entities/TaxjarError.cs
@@ -2,15 +2,15 @@
 
 namespace Taxjar
 {
-	public class TaxjarError
-	{
-		[JsonProperty("error")]
-		public string Error { get; set; }
+    public class TaxjarError
+    {
+        [JsonProperty("error")]
+        public string Error { get; set; }
 
-		[JsonProperty("detail")]
-		public string Detail { get; set; }
+        [JsonProperty("detail")]
+        public string Detail { get; set; }
 
-		[JsonProperty("status")]
-		public string StatusCode { get; set; }
-	}
+        [JsonProperty("status")]
+        public string StatusCode { get; set; }
+    }
 }

--- a/src/Taxjar/Entities/TaxjarLineItem.cs
+++ b/src/Taxjar/Entities/TaxjarLineItem.cs
@@ -2,30 +2,30 @@
 
 namespace Taxjar
 {
-	public class LineItem
-	{
-		[JsonProperty("id")]
-		public string Id { get; set; }
+    public class LineItem
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-		[JsonProperty("quantity")]
-		public int Quantity { get; set; }
+        [JsonProperty("quantity")]
+        public int Quantity { get; set; }
 
-		[JsonProperty("product_identifier")]
-		public string ProductIdentifier { get; set; }
+        [JsonProperty("product_identifier")]
+        public string ProductIdentifier { get; set; }
 
-		[JsonProperty("description")]
-		public string Description { get; set; }
+        [JsonProperty("description")]
+        public string Description { get; set; }
 
-		[JsonProperty("product_tax_code")]
-		public string ProductTaxCode { get; set; }
+        [JsonProperty("product_tax_code")]
+        public string ProductTaxCode { get; set; }
 
-		[JsonProperty("unit_price")]
-		public decimal UnitPrice { get; set; }
+        [JsonProperty("unit_price")]
+        public decimal UnitPrice { get; set; }
 
-		[JsonProperty("discount")]
-		public decimal Discount { get; set; }
+        [JsonProperty("discount")]
+        public decimal Discount { get; set; }
 
-		[JsonProperty("sales_tax")]
-		public decimal SalesTax { get; set; }
-	}
+        [JsonProperty("sales_tax")]
+        public decimal SalesTax { get; set; }
+    }
 }

--- a/src/Taxjar/Entities/TaxjarNexusRegion.cs
+++ b/src/Taxjar/Entities/TaxjarNexusRegion.cs
@@ -3,24 +3,24 @@ using Newtonsoft.Json;
 
 namespace Taxjar
 {
-	public class NexusRegionsResponse
-	{
-		[JsonProperty("regions")]
+    public class NexusRegionsResponse
+    {
+        [JsonProperty("regions")]
         public List<NexusRegion> Regions { get; set; }
-	}
+    }
 
-	public class NexusRegion
-	{
-		[JsonProperty("country_code")]
-		public string CountryCode { get; set; }
+    public class NexusRegion
+    {
+        [JsonProperty("country_code")]
+        public string CountryCode { get; set; }
 
-		[JsonProperty("country")]
-		public string Country { get; set; }
+        [JsonProperty("country")]
+        public string Country { get; set; }
 
-		[JsonProperty("region_code")]
-		public string RegionCode { get; set; }
+        [JsonProperty("region_code")]
+        public string RegionCode { get; set; }
 
-		[JsonProperty("region")]
-		public string Region { get; set; }
-	}
+        [JsonProperty("region")]
+        public string Region { get; set; }
+    }
 }

--- a/src/Taxjar/Entities/TaxjarRate.cs
+++ b/src/Taxjar/Entities/TaxjarRate.cs
@@ -2,71 +2,71 @@
 
 namespace Taxjar
 {
-	public class RateResponse
-	{
-		[JsonProperty("rate")]
+    public class RateResponse
+    {
+        [JsonProperty("rate")]
         public RateResponseAttributes Rate { get; set; }
-	}
+    }
 
-	public class RateResponseAttributes
-	{
-		[JsonProperty("zip")]
-		public string Zip { get; set; }
+    public class RateResponseAttributes
+    {
+        [JsonProperty("zip")]
+        public string Zip { get; set; }
 
-		[JsonProperty("state")]
-		public string State { get; set; }
+        [JsonProperty("state")]
+        public string State { get; set; }
 
-		[JsonProperty("state_rate")]
-		public decimal StateRate { get; set; }
+        [JsonProperty("state_rate")]
+        public decimal StateRate { get; set; }
 
-		[JsonProperty("county")]
-		public string County { get; set; }
+        [JsonProperty("county")]
+        public string County { get; set; }
 
-		[JsonProperty("county_rate")]
-		public decimal CountyRate { get; set; }
+        [JsonProperty("county_rate")]
+        public decimal CountyRate { get; set; }
 
-		[JsonProperty("city")]
-		public string City { get; set; }
+        [JsonProperty("city")]
+        public string City { get; set; }
 
-		[JsonProperty("city_rate")]
-		public decimal CityRate { get; set; }
+        [JsonProperty("city_rate")]
+        public decimal CityRate { get; set; }
 
-		[JsonProperty("combined_district_rate")]
-		public decimal CombinedDistrictRate { get; set; }
+        [JsonProperty("combined_district_rate")]
+        public decimal CombinedDistrictRate { get; set; }
 
-		[JsonProperty("combined_rate")]
-		public decimal CombinedRate { get; set; }
+        [JsonProperty("combined_rate")]
+        public decimal CombinedRate { get; set; }
 
-		[JsonProperty("freight_taxable")]
-		public bool FreightTaxable { get; set; }
+        [JsonProperty("freight_taxable")]
+        public bool FreightTaxable { get; set; }
 
-		// International
-		[JsonProperty("country")]
-		public string Country { get; set; }
+        // International
+        [JsonProperty("country")]
+        public string Country { get; set; }
 
-		[JsonProperty("name")]
-		public string Name { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-		// Australia / SST States
-		[JsonProperty("country_rate")]
-		public decimal CountryRate { get; set; }
+        // Australia / SST States
+        [JsonProperty("country_rate")]
+        public decimal CountryRate { get; set; }
 
-		// European Union
-		[JsonProperty("standard_rate")]
-		public decimal StandardRate { get; set; }
+        // European Union
+        [JsonProperty("standard_rate")]
+        public decimal StandardRate { get; set; }
 
-		[JsonProperty("reduced_rate", NullValueHandling = NullValueHandling.Ignore)]
-		public decimal ReducedRate { get; set; }
+        [JsonProperty("reduced_rate", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal ReducedRate { get; set; }
 
-		[JsonProperty("super_reduced_rate", NullValueHandling = NullValueHandling.Ignore)]
-		public decimal SuperReducedRate { get; set; }
+        [JsonProperty("super_reduced_rate", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal SuperReducedRate { get; set; }
 
-		[JsonProperty("parking_rate", NullValueHandling = NullValueHandling.Ignore)]
-		public decimal ParkingRate { get; set; }
+        [JsonProperty("parking_rate", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal ParkingRate { get; set; }
 
-		[JsonProperty("distance_sale_threshold", NullValueHandling = NullValueHandling.Ignore)]
-		public decimal DistanceSaleThreshold { get; set; }
-	}
+        [JsonProperty("distance_sale_threshold", NullValueHandling = NullValueHandling.Ignore)]
+        public decimal DistanceSaleThreshold { get; set; }
+    }
 
     public class Rate
     {

--- a/src/Taxjar/Entities/TaxjarSummaryRate.cs
+++ b/src/Taxjar/Entities/TaxjarSummaryRate.cs
@@ -3,39 +3,39 @@ using Newtonsoft.Json;
 
 namespace Taxjar
 {
-	public class SummaryRatesResponse
-	{
-		[JsonProperty("summary_rates")]
-		public List<SummaryRate> SummaryRates { get; set; }
-	}
+    public class SummaryRatesResponse
+    {
+        [JsonProperty("summary_rates")]
+        public List<SummaryRate> SummaryRates { get; set; }
+    }
 
-	public class SummaryRate
-	{
-		[JsonProperty("country_code")]
-		public string CountryCode { get; set; }
+    public class SummaryRate
+    {
+        [JsonProperty("country_code")]
+        public string CountryCode { get; set; }
 
-		[JsonProperty("country")]
-		public string Country { get; set; }
+        [JsonProperty("country")]
+        public string Country { get; set; }
 
-		[JsonProperty("region_code")]
-		public string RegionCode { get; set; }
+        [JsonProperty("region_code")]
+        public string RegionCode { get; set; }
 
-		[JsonProperty("region")]
-		public string Region { get; set; }
+        [JsonProperty("region")]
+        public string Region { get; set; }
 
-		[JsonProperty("minimum_rate")]
-		public SummaryRateObject MinimumRate { get; set; }
+        [JsonProperty("minimum_rate")]
+        public SummaryRateObject MinimumRate { get; set; }
 
-		[JsonProperty("average_rate")]
-		public SummaryRateObject AverageRate { get; set; }
-	}
+        [JsonProperty("average_rate")]
+        public SummaryRateObject AverageRate { get; set; }
+    }
 
-	public class SummaryRateObject
-	{
-		[JsonProperty("label")]
-		public string Label { get; set; }
+    public class SummaryRateObject
+    {
+        [JsonProperty("label")]
+        public string Label { get; set; }
 
-		[JsonProperty("rate")]
-		public decimal Rate { get; set; }
-	}
+        [JsonProperty("rate")]
+        public decimal Rate { get; set; }
+    }
 }

--- a/src/Taxjar/Entities/TaxjarTax.cs
+++ b/src/Taxjar/Entities/TaxjarTax.cs
@@ -3,37 +3,37 @@ using Newtonsoft.Json;
 
 namespace Taxjar
 {
-	public class TaxResponse
-	{
-		[JsonProperty("tax")]
+    public class TaxResponse
+    {
+        [JsonProperty("tax")]
         public TaxResponseAttributes Tax { get; set; }
-	}
+    }
 
-	public class TaxResponseAttributes
-	{
-		[JsonProperty("order_total_amount")]
-		public decimal OrderTotalAmount { get; set; }
+    public class TaxResponseAttributes
+    {
+        [JsonProperty("order_total_amount")]
+        public decimal OrderTotalAmount { get; set; }
 
-		[JsonProperty("shipping")]
-		public decimal Shipping { get; set; }
+        [JsonProperty("shipping")]
+        public decimal Shipping { get; set; }
 
-		[JsonProperty("taxable_amount")]
-		public decimal TaxableAmount { get; set; }
+        [JsonProperty("taxable_amount")]
+        public decimal TaxableAmount { get; set; }
 
-		[JsonProperty("amount_to_collect")]
-		public decimal AmountToCollect { get; set; }
+        [JsonProperty("amount_to_collect")]
+        public decimal AmountToCollect { get; set; }
 
-		[JsonProperty("rate")]
-		public decimal Rate { get; set; }
+        [JsonProperty("rate")]
+        public decimal Rate { get; set; }
 
-		[JsonProperty("has_nexus")]
-		public bool HasNexus { get; set; }
+        [JsonProperty("has_nexus")]
+        public bool HasNexus { get; set; }
 
-		[JsonProperty("freight_taxable")]
-		public bool FreightTaxable { get; set; }
+        [JsonProperty("freight_taxable")]
+        public bool FreightTaxable { get; set; }
 
-		[JsonProperty("tax_source")]
-		public string TaxSource { get; set; }
+        [JsonProperty("tax_source")]
+        public string TaxSource { get; set; }
 
         [JsonProperty("exemption_type")]
         public string ExemptionType { get; set; }
@@ -41,9 +41,9 @@ namespace Taxjar
         [JsonProperty("jurisdictions")]
         public TaxJurisdictions Jurisdictions { get; set; }
 
-		[JsonProperty("breakdown")]
-		public TaxBreakdown Breakdown { get; set; }
-	}
+        [JsonProperty("breakdown")]
+        public TaxBreakdown Breakdown { get; set; }
+    }
 
     public class Tax
     {

--- a/src/Taxjar/Entities/TaxjarTaxBreakdown.cs
+++ b/src/Taxjar/Entities/TaxjarTaxBreakdown.cs
@@ -3,33 +3,33 @@ using Newtonsoft.Json;
 
 namespace Taxjar
 {
-	public class TaxBreakdown : Breakdown
-	{
-		[JsonProperty("state_tax_rate")]
-		public decimal StateTaxRate { get; set; }
+    public class TaxBreakdown : Breakdown
+    {
+        [JsonProperty("state_tax_rate")]
+        public decimal StateTaxRate { get; set; }
 
-		[JsonProperty("state_tax_collectable")]
-		public decimal StateTaxCollectable { get; set; }
+        [JsonProperty("state_tax_collectable")]
+        public decimal StateTaxCollectable { get; set; }
 
-		[JsonProperty("county_tax_collectable")]
-		public decimal CountyTaxCollectable { get; set; }
+        [JsonProperty("county_tax_collectable")]
+        public decimal CountyTaxCollectable { get; set; }
 
-		[JsonProperty("city_tax_collectable")]
-		public decimal CityTaxCollectable { get; set; }
+        [JsonProperty("city_tax_collectable")]
+        public decimal CityTaxCollectable { get; set; }
 
-		[JsonProperty("special_district_taxable_amount")]
-		public decimal SpecialDistrictTaxableAmount { get; set; }
+        [JsonProperty("special_district_taxable_amount")]
+        public decimal SpecialDistrictTaxableAmount { get; set; }
 
-		[JsonProperty("special_tax_rate")]
-		public decimal SpecialDistrictTaxRate { get; set; }
+        [JsonProperty("special_tax_rate")]
+        public decimal SpecialDistrictTaxRate { get; set; }
 
-		[JsonProperty("special_district_tax_collectable")]
-		public decimal SpecialDistrictTaxCollectable { get; set; }
+        [JsonProperty("special_district_tax_collectable")]
+        public decimal SpecialDistrictTaxCollectable { get; set; }
 
-		[JsonProperty("shipping")]
-		public TaxBreakdownShipping Shipping { get; set; }
+        [JsonProperty("shipping")]
+        public TaxBreakdownShipping Shipping { get; set; }
 
-		[JsonProperty("line_items")]
-		public List<TaxBreakdownLineItem> LineItems { get; set; }
-	}
+        [JsonProperty("line_items")]
+        public List<TaxBreakdownLineItem> LineItems { get; set; }
+    }
 }

--- a/src/Taxjar/Entities/TaxjarTaxBreakdownLineItem.cs
+++ b/src/Taxjar/Entities/TaxjarTaxBreakdownLineItem.cs
@@ -2,30 +2,30 @@
 
 namespace Taxjar
 {
-	public class TaxBreakdownLineItem : Breakdown
-	{
-		[JsonProperty("id")]
-		public string Id { get; set; }
+    public class TaxBreakdownLineItem : Breakdown
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
 
-		[JsonProperty("state_sales_tax_rate")]
-		public decimal StateSalesTaxRate { get; set; }
+        [JsonProperty("state_sales_tax_rate")]
+        public decimal StateSalesTaxRate { get; set; }
 
-		[JsonProperty("state_amount")]
-		public decimal StateAmount { get; set; }
+        [JsonProperty("state_amount")]
+        public decimal StateAmount { get; set; }
 
-		[JsonProperty("county_amount")]
-		public decimal CountyAmount { get; set; }
+        [JsonProperty("county_amount")]
+        public decimal CountyAmount { get; set; }
 
-		[JsonProperty("city_amount")]
-		public decimal CityAmount { get; set; }
+        [JsonProperty("city_amount")]
+        public decimal CityAmount { get; set; }
 
-		[JsonProperty("special_district_taxable_amount")]
-		public decimal SpecialDistrictTaxableAmount { get; set; }
+        [JsonProperty("special_district_taxable_amount")]
+        public decimal SpecialDistrictTaxableAmount { get; set; }
 
-		[JsonProperty("special_tax_rate")]
-		public decimal SpecialTaxRate { get; set; }
+        [JsonProperty("special_tax_rate")]
+        public decimal SpecialTaxRate { get; set; }
 
-		[JsonProperty("special_district_amount")]
-		public decimal SpecialDistrictAmount { get; set; }
-	}
+        [JsonProperty("special_district_amount")]
+        public decimal SpecialDistrictAmount { get; set; }
+    }
 }

--- a/src/Taxjar/Entities/TaxjarTaxBreakdownShipping.cs
+++ b/src/Taxjar/Entities/TaxjarTaxBreakdownShipping.cs
@@ -2,27 +2,27 @@
 
 namespace Taxjar
 {
-	public class TaxBreakdownShipping : Breakdown
-	{
-		[JsonProperty("state_sales_tax_rate")]
-		public decimal StateSalesTaxRate { get; set; }
+    public class TaxBreakdownShipping : Breakdown
+    {
+        [JsonProperty("state_sales_tax_rate")]
+        public decimal StateSalesTaxRate { get; set; }
 
-		[JsonProperty("state_amount")]
-		public decimal StateAmount { get; set; }
+        [JsonProperty("state_amount")]
+        public decimal StateAmount { get; set; }
 
-		[JsonProperty("county_amount")]
-		public decimal CountyAmount { get; set; }
+        [JsonProperty("county_amount")]
+        public decimal CountyAmount { get; set; }
 
-		[JsonProperty("city_amount")]
-		public decimal CityAmount { get; set; }
+        [JsonProperty("city_amount")]
+        public decimal CityAmount { get; set; }
 
-		[JsonProperty("special_taxable_amount")]
-		public decimal SpecialDistrictTaxableAmount { get; set; }
+        [JsonProperty("special_taxable_amount")]
+        public decimal SpecialDistrictTaxableAmount { get; set; }
 
-		[JsonProperty("special_tax_rate")]
-		public decimal SpecialDistrictTaxRate { get; set; }
+        [JsonProperty("special_tax_rate")]
+        public decimal SpecialDistrictTaxRate { get; set; }
 
-		[JsonProperty("special_district_amount")]
-		public decimal SpecialDistrictAmount { get; set; }
-	}
+        [JsonProperty("special_district_amount")]
+        public decimal SpecialDistrictAmount { get; set; }
+    }
 }

--- a/src/Taxjar/Entities/TaxjarValidation.cs
+++ b/src/Taxjar/Entities/TaxjarValidation.cs
@@ -2,47 +2,47 @@
 
 namespace Taxjar
 {
-	public class ValidationResponse
-	{
-		[JsonProperty("validation")]
+    public class ValidationResponse
+    {
+        [JsonProperty("validation")]
         public ValidationResponseAttributes Validation { get; set; }
-	}
+    }
 
-	public class ValidationResponseAttributes
-	{
-		[JsonProperty("valid")]
-		public bool Valid { get; set; }
+    public class ValidationResponseAttributes
+    {
+        [JsonProperty("valid")]
+        public bool Valid { get; set; }
 
-		[JsonProperty("exists")]
-		public bool Exists { get; set; }
+        [JsonProperty("exists")]
+        public bool Exists { get; set; }
 
-		[JsonProperty("vies_available")]
-		public bool ViesAvailable { get; set; }
+        [JsonProperty("vies_available")]
+        public bool ViesAvailable { get; set; }
 
-		[JsonProperty("vies_response")]
-		public ViesResponse ViesResponse { get; set; }
-	}
+        [JsonProperty("vies_response")]
+        public ViesResponse ViesResponse { get; set; }
+    }
 
-	public class ViesResponse
-	{
-		[JsonProperty("country_code")]
-		public string CountryCode { get; set; }
+    public class ViesResponse
+    {
+        [JsonProperty("country_code")]
+        public string CountryCode { get; set; }
 
-		[JsonProperty("vat_number")]
-		public string VatNumber { get; set; }
+        [JsonProperty("vat_number")]
+        public string VatNumber { get; set; }
 
-		[JsonProperty("request_date")]
-		public string RequestDate { get; set; }
+        [JsonProperty("request_date")]
+        public string RequestDate { get; set; }
 
-		[JsonProperty("valid")]
-		public bool Valid { get; set; }
+        [JsonProperty("valid")]
+        public bool Valid { get; set; }
 
-		[JsonProperty("name")]
-		public string Name { get; set; }
+        [JsonProperty("name")]
+        public string Name { get; set; }
 
-		[JsonProperty("address")]
-		public string Address { get; set; }
-	}
+        [JsonProperty("address")]
+        public string Address { get; set; }
+    }
 
     public class Validation
     {

--- a/src/Taxjar/Infrastructure/TaxjarException.cs
+++ b/src/Taxjar/Infrastructure/TaxjarException.cs
@@ -3,21 +3,20 @@ using System.Net;
 
 namespace Taxjar
 {
-	[Serializable]
-	public class TaxjarException : ApplicationException
-	{
-		public HttpStatusCode HttpStatusCode { get; set; }
-		public TaxjarError TaxjarError { get; set; }
+    [Serializable]
+    public class TaxjarException : ApplicationException
+    {
+        public HttpStatusCode HttpStatusCode { get; set; }
+        public TaxjarError TaxjarError { get; set; }
 
-		public TaxjarException()
-		{
-		}
+        public TaxjarException()
+        {
+        }
 
-		public TaxjarException(HttpStatusCode statusCode, TaxjarError taxjarError, string message) : base(message)
-		{
-			HttpStatusCode = statusCode;
-			TaxjarError = taxjarError;
-		}
-	}
+        public TaxjarException(HttpStatusCode statusCode, TaxjarError taxjarError, string message) : base(message)
+        {
+            HttpStatusCode = statusCode;
+            TaxjarError = taxjarError;
+        }
+    }
 }
-


### PR DESCRIPTION
There was a mixture of tabs and (4) spaces for indentation in certain files. We're converting all tabs to (4) spaces in `.cs` files for consistency.

Going forward, an `.editorconfig` file will be in place to signal to IDEs our preferred settings for each file type.

| File type | Whitespace |
|----------|-------------|
| *.cs and other file types| 4 spaces |
| *.sln | tabs (required) |
|*.json, *.csproj, *.props, *.targets | 2 spaces |