### PR TITLE
Handle null values for `exemption_type` and `provider` correctly

### DIFF
--- a/src/Taxjar/Entities/TaxjarOrder.cs
+++ b/src/Taxjar/Entities/TaxjarOrder.cs
@@ -83,10 +83,10 @@ namespace Taxjar
         [JsonProperty("transaction_date")]
         public string TransactionDate { get; set; }
 
-        [JsonProperty("provider")]
+        [JsonProperty("provider", NullValueHandling = NullValueHandling.Ignore)]
         public string Provider { get; set; }
 
-        [JsonProperty("exemption_type")]
+        [JsonProperty("exemption_type", NullValueHandling = NullValueHandling.Ignore)]
         public string ExemptionType { get; set; }
 
         [JsonProperty("from_country")]

--- a/src/Taxjar/Entities/TaxjarRefund.cs
+++ b/src/Taxjar/Entities/TaxjarRefund.cs
@@ -89,10 +89,10 @@ namespace Taxjar
         [JsonProperty("transaction_date")]
         public string TransactionDate { get; set; }
 
-        [JsonProperty("provider")]
+        [JsonProperty("provider", NullValueHandling = NullValueHandling.Ignore)]
         public string Provider { get; set; }
 
-        [JsonProperty("exemption_type")]
+        [JsonProperty("exemption_type", NullValueHandling = NullValueHandling.Ignore)]
         public string ExemptionType { get; set; }
 
         [JsonProperty("from_country")]

--- a/src/Taxjar/Entities/TaxjarTax.cs
+++ b/src/Taxjar/Entities/TaxjarTax.cs
@@ -86,7 +86,7 @@ namespace Taxjar
         [JsonProperty("customer_id")]
         public string CustomerId { get; set; }
 
-        [JsonProperty("exemption_type")]
+        [JsonProperty("exemption_type", NullValueHandling = NullValueHandling.Ignore)]
         public string ExemptionType { get; set; }
 
         [JsonProperty("nexus_addresses")]


### PR DESCRIPTION
Both the `exemption_type` and `provider` params are optional when passed to the TaxJar API. Therefore, users should be able to exclude these params when sending tax calculations or transactions.

This works as intended for anonymous objects:
```csharp
var tax = client.TaxForOrder(new {
    to_country = "US",
    to_zip = "94040",
    to_state = "CA",
    shipping = 5
    // exemption_type = "non_exempt"
    ...
});
```

However, prior to this PR the `Tax`, `Order`, and `Refund` objects were not correctly handling null values for the optional `ExemptionType` and `Provider` params:
```csharp
var tax = client.TaxForOrder(new Tax() {
    ToCountry = "US",
    ToZip = "94040",
    ToState = "CA",
    Shipping = 5
    // ExemptionType = "non_exempt"
    ...
});
```

`Taxjar.TaxjarException: Not Acceptable - exemption_type must be one of: non_exempt, government, wholesale, other`

Now, null values passed to the optional `ExemptionType` and `Provider` params will properly be ignored.