### PR TITLE
Update RestSharp to v106.10.1

### DIFF
--- a/build/TaxJar.nuspec
+++ b/build/TaxJar.nuspec
@@ -20,7 +20,7 @@
     <dependencies>
       <group>
         <dependency id="Newtonsoft.Json" version="12.0.3" />
-        <dependency id="RestSharp" version="[106.6.9,107.0.0)" />
+        <dependency id="RestSharp" version="[106.10.1,107.0.0)" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Taxjar.Tests/TaxJar.Tests.csproj
+++ b/src/Taxjar.Tests/TaxJar.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="RestSharp" Version="106.6.9" />
+    <PackageReference Include="RestSharp" Version="106.10.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="WireMock.Net.StandAlone" Version="1.0.19.0" />
     <PackageReference Include="DotNetEnv" Version="1.1.0" />

--- a/src/Taxjar/Taxjar.csproj
+++ b/src/Taxjar/Taxjar.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.6.9" />
+    <PackageReference Include="RestSharp" Version="106.10.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -151,7 +151,7 @@ namespace Taxjar
         protected virtual async Task<T> SendRequestAsync<T>(string endpoint, object body = null, Method httpMethod = Method.POST) where T : new()
         {
             var request = CreateRequest(endpoint, httpMethod, body);
-            var response = await apiClient.ExecuteTaskAsync<T>(request);
+            var response = await apiClient.ExecuteAsync<T>(request);
 
             if ((int)response.StatusCode >= 400)
             {

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
@@ -81,6 +82,7 @@ namespace Taxjar
             {
                 RequestFormat = DataFormat.Json
             };
+            var includeBody = new[] {Method.POST, Method.PUT, Method.PATCH}.Contains(method);
 
             request.AddHeader("Authorization", "Bearer " + apiToken);
 
@@ -95,21 +97,25 @@ namespace Taxjar
             {
                 if (IsAnonymousType(body.GetType()))
                 {
-                    if (method == Method.GET)
+                    if (includeBody)
+                    {
+                        request.AddJsonBody(body);
+                    }
+                    else
                     {
                         foreach (var prop in body.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
                         {
                             request.AddQueryParameter(prop.Name, prop.GetValue(body).ToString());
                         }
                     }
-                    else
-                    {
-                        request.AddJsonBody(body);
-                    }
                 }
                 else
                 {
-                    if (method == Method.GET)
+                    if (includeBody)
+                    {
+                        request.AddParameter("application/json", JsonConvert.SerializeObject(body), ParameterType.RequestBody);
+                    }
+                    else
                     {
                         body = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(body));
 
@@ -117,10 +123,6 @@ namespace Taxjar
                         {
                             request.AddQueryParameter(prop.Name, prop.Value.ToString());
                         }
-                    }
-                    else
-                    {
-                        request.AddParameter("application/json", JsonConvert.SerializeObject(body), ParameterType.RequestBody);
                     }
                 }
             }

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -95,8 +95,6 @@ namespace Taxjar
             {
                 if (IsAnonymousType(body.GetType()))
                 {
-                    request.AddJsonBody(body);
-
                     if (method == Method.GET)
                     {
                         foreach (var prop in body.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
@@ -104,11 +102,13 @@ namespace Taxjar
                             request.AddQueryParameter(prop.Name, prop.GetValue(body).ToString());
                         }
                     }
+                    else
+                    {
+                        request.AddJsonBody(body);
+                    }
                 }
                 else
                 {
-                    request.AddParameter("application/json", JsonConvert.SerializeObject(body), ParameterType.RequestBody);
-
                     if (method == Method.GET)
                     {
                         body = JsonConvert.DeserializeObject(JsonConvert.SerializeObject(body));
@@ -117,6 +117,10 @@ namespace Taxjar
                         {
                             request.AddQueryParameter(prop.Name, prop.Value.ToString());
                         }
+                    }
+                    else
+                    {
+                        request.AddParameter("application/json", JsonConvert.SerializeObject(body), ParameterType.RequestBody);
                     }
                 }
             }


### PR DESCRIPTION
This PR updates RestSharp to the latest version, `106.10.1`.

Additionally:

- RestSharp no longer allows adding a JSON body to GET requests, so we'll now skip that step for all GET requests.
- `ExecuteTaskAsync` is now deprecated, so we'll switch to `ExecuteAsync`.