### PR TITLE
Add `ConfigureAwait(false)` to awaited tasks to improve performance

### DIFF
--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -153,7 +153,7 @@ namespace Taxjar
         protected virtual async Task<T> SendRequestAsync<T>(string endpoint, object body = null, Method httpMethod = Method.POST) where T : new()
         {
             var request = CreateRequest(endpoint, httpMethod, body);
-            var response = await apiClient.ExecuteAsync<T>(request);
+            var response = await apiClient.ExecuteAsync<T>(request).ConfigureAwait(false);
 
             if ((int)response.StatusCode >= 400)
             {
@@ -340,136 +340,136 @@ namespace Taxjar
 
         public virtual async Task<List<Category>> CategoriesAsync()
         {
-            var response = await SendRequestAsync<CategoriesResponse>("categories", null, Method.GET);
+            var response = await SendRequestAsync<CategoriesResponse>("categories", null, Method.GET).ConfigureAwait(false);
             return response.Categories;
         }
 
         public virtual async Task<RateResponseAttributes> RatesForLocationAsync(string zip, object parameters = null)
         {
-            var response = await SendRequestAsync<RateResponse>("rates/" + zip, parameters, Method.GET);
+            var response = await SendRequestAsync<RateResponse>("rates/" + zip, parameters, Method.GET).ConfigureAwait(false);
             return response.Rate;
         }
 
         public virtual async Task<TaxResponseAttributes> TaxForOrderAsync(object parameters)
         {
-            var response = await SendRequestAsync<TaxResponse>("taxes", parameters, Method.POST);
+            var response = await SendRequestAsync<TaxResponse>("taxes", parameters, Method.POST).ConfigureAwait(false);
             return response.Tax;
         }
 
         public virtual async Task<List<string>> ListOrdersAsync(object parameters = null)
         {
-            var response = await SendRequestAsync<OrdersResponse>("transactions/orders", parameters, Method.GET);
+            var response = await SendRequestAsync<OrdersResponse>("transactions/orders", parameters, Method.GET).ConfigureAwait(false);
             return response.Orders;
         }
 
         public virtual async Task<OrderResponseAttributes> ShowOrderAsync(string transactionId, object parameters = null)
         {
-            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.GET);
+            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.GET).ConfigureAwait(false);
             return response.Order;
         }
 
         public virtual async Task<OrderResponseAttributes> CreateOrderAsync(object parameters)
         {
-            var response = await SendRequestAsync<OrderResponse> ("transactions/orders", parameters, Method.POST);
+            var response = await SendRequestAsync<OrderResponse> ("transactions/orders", parameters, Method.POST).ConfigureAwait(false);
             return response.Order;
         }
 
         public virtual async Task<OrderResponseAttributes> UpdateOrderAsync(object parameters)
         {
             var transactionId = parameters.GetType().GetProperty("transaction_id").GetValue(parameters).ToString();
-            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.PUT);
+            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.PUT).ConfigureAwait(false);
             return response.Order;
         }
 
         public virtual async Task<OrderResponseAttributes> DeleteOrderAsync(string transactionId, object parameters = null)
         {
-            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.DELETE);
+            var response = await SendRequestAsync<OrderResponse>("transactions/orders/" + transactionId, parameters, Method.DELETE).ConfigureAwait(false);
             return response.Order;
         }
 
         public virtual async Task<List<string>> ListRefundsAsync(object parameters)
         {
-            var response = await SendRequestAsync<RefundsResponse>("transactions/refunds", parameters, Method.GET);
+            var response = await SendRequestAsync<RefundsResponse>("transactions/refunds", parameters, Method.GET).ConfigureAwait(false);
             return response.Refunds;
         }
 
         public virtual async Task<RefundResponseAttributes> ShowRefundAsync(string transactionId, object parameters = null)
         {
-            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.GET);
+            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.GET).ConfigureAwait(false);
             return response.Refund;
         }
 
         public virtual async Task<RefundResponseAttributes> CreateRefundAsync(object parameters)
         {
-            var response = await SendRequestAsync<RefundResponse>("transactions/refunds", parameters, Method.POST);
+            var response = await SendRequestAsync<RefundResponse>("transactions/refunds", parameters, Method.POST).ConfigureAwait(false);
             return response.Refund;
         }
 
         public virtual async Task<RefundResponseAttributes> UpdateRefundAsync(object parameters)
         {
             var transactionId = parameters.GetType().GetProperty("transaction_id").GetValue(parameters).ToString();
-            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.PUT);
+            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.PUT).ConfigureAwait(false);
             return response.Refund;
         }
 
         public virtual async Task<RefundResponseAttributes> DeleteRefundAsync(string transactionId, object parameters = null)
         {
-            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.DELETE);
+            var response = await SendRequestAsync<RefundResponse>("transactions/refunds/" + transactionId, parameters, Method.DELETE).ConfigureAwait(false);
             return response.Refund;
         }
 
         public virtual async Task<List<string>> ListCustomersAsync(object parameters = null)
         {
-            var response = await SendRequestAsync<CustomersResponse>("customers", parameters, Method.GET);
+            var response = await SendRequestAsync<CustomersResponse>("customers", parameters, Method.GET).ConfigureAwait(false);
             return response.Customers;
         }
 
         public virtual async Task<CustomerResponseAttributes> ShowCustomerAsync(string customerId)
         {
-            var response = await SendRequestAsync<CustomerResponse>("customers/" + customerId, null, Method.GET);
+            var response = await SendRequestAsync<CustomerResponse>("customers/" + customerId, null, Method.GET).ConfigureAwait(false);
             return response.Customer;
         }
 
         public virtual async Task<CustomerResponseAttributes> CreateCustomerAsync(object parameters)
         {
-            var response = await SendRequestAsync<CustomerResponse>("customers", parameters, Method.POST);
+            var response = await SendRequestAsync<CustomerResponse>("customers", parameters, Method.POST).ConfigureAwait(false);
             return response.Customer;
         }
 
         public virtual async Task<CustomerResponseAttributes> UpdateCustomerAsync(object parameters)
         {
             var customerId = parameters.GetType().GetProperty("customer_id").GetValue(parameters).ToString();
-            var response = await SendRequestAsync<CustomerResponse>("customers/" + customerId, parameters, Method.PUT);
+            var response = await SendRequestAsync<CustomerResponse>("customers/" + customerId, parameters, Method.PUT).ConfigureAwait(false);
             return response.Customer;
         }
 
         public virtual async Task<CustomerResponseAttributes> DeleteCustomerAsync(string customerId)
         {
-            var response = await SendRequestAsync<CustomerResponse>("customers/" + customerId, null, Method.DELETE);
+            var response = await SendRequestAsync<CustomerResponse>("customers/" + customerId, null, Method.DELETE).ConfigureAwait(false);
             return response.Customer;
         }
 
         public virtual async Task<List<NexusRegion>> NexusRegionsAsync()
         {
-            var response = await SendRequestAsync<NexusRegionsResponse>("nexus/regions", null, Method.GET);
+            var response = await SendRequestAsync<NexusRegionsResponse>("nexus/regions", null, Method.GET).ConfigureAwait(false);
             return response.Regions;
         }
 
         public virtual async Task<List<Address>> ValidateAddressAsync(object parameters)
         {
-            var response = await SendRequestAsync<AddressValidationResponse>("addresses/validate", parameters, Method.POST);
+            var response = await SendRequestAsync<AddressValidationResponse>("addresses/validate", parameters, Method.POST).ConfigureAwait(false);
             return response.Addresses;
         }
 
         public virtual async Task<ValidationResponseAttributes> ValidateVatAsync(object parameters)
         {
-            var response = await SendRequestAsync<ValidationResponse>("validation", parameters, Method.GET);
+            var response = await SendRequestAsync<ValidationResponse>("validation", parameters, Method.GET).ConfigureAwait(false);
             return response.Validation;
         }
 
         public virtual async Task<List<SummaryRate>> SummaryRatesAsync()
         {
-            var response = await SendRequestAsync<SummaryRatesResponse>("summary_rates", null, Method.GET);
+            var response = await SendRequestAsync<SummaryRatesResponse>("summary_rates", null, Method.GET).ConfigureAwait(false);
             return response.SummaryRates;
         }
     }


### PR DESCRIPTION
Best practice is to add `ConfigureAwait(false)` to `await`ed tasks in library code. This helps avoid deadlocks and improves performance by avoiding the overhead of continuing in the original context. See https://devblogs.microsoft.com/dotnet/configureawait-faq/ for further details.