### PR TITLE
Add a custom user agent to each request

### DIFF
--- a/src/Taxjar/Taxjar.csproj
+++ b/src/Taxjar/Taxjar.csproj
@@ -13,6 +13,7 @@
     <PackageProjectUrl>https://github.com/taxjar/taxjar.net</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/taxjar/taxjar.net/blob/master/LICENSE.txt</PackageLicenseUrl>
     <ReleaseVersion>3.2.1</ReleaseVersion>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net452' ">NET452</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -58,6 +59,7 @@ namespace Taxjar
             }
 
             apiClient = new RestClient(apiUrl);
+            apiClient.UserAgent = getUserAgent();
         }
 
         public virtual void SetApiConfig(string key, object value)
@@ -66,6 +68,7 @@ namespace Taxjar
             {
                 value += "/" + TaxjarConstants.ApiVersion + "/";
                 apiClient = new RestClient(value.ToString());
+                apiClient.UserAgent = getUserAgent();
             }
 
             GetType().GetProperty(key).SetValue(this, value, null);
@@ -471,6 +474,16 @@ namespace Taxjar
         {
             var response = await SendRequestAsync<SummaryRatesResponse>("summary_rates", null, Method.GET).ConfigureAwait(false);
             return response.SummaryRates;
+        }
+
+        private string getUserAgent()
+        {
+            String platform = RuntimeInformation.OSDescription;
+            String arch = RuntimeInformation.OSArchitecture.ToString();
+            String framework = RuntimeInformation.FrameworkDescription;
+            String version = GetType().Assembly.GetName().Version.ToString(3);
+
+            return $"TaxJar/.NET ({platform}; {arch}; {framework}) taxjar.net/{version}";
         }
     }
 }


### PR DESCRIPTION
To help debug technical issues, it's necessary to collect additional information about a user's server.

For that purpose, this PR adds a custom user agent string to each request, which includes the following information:

- Operating system
- Framework and version
- Version of taxjar.net currently being used

Example UA string:
<img width="742" alt="Screen Shot 2020-03-25 at 12 51 55 AM" src="https://user-images.githubusercontent.com/26824724/77556310-964bcb00-6e75-11ea-9bf9-f89abdc9b04d.png">