### PR TITLE
Set up GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  release:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract TaxJar Version
+        run: echo ::set-env name=TAXJAR_VERSION::$(echo ${GITHUB_REF:11})
+      - name: Build release DLL for .NET Standard 2.0
+        run: |
+          sed -i 's/^\(\s*\)<TargetFrameworks>.*$/\1<TargetFrameworks>netstandard2.0<\/TargetFrameworks>/' src/Taxjar/Taxjar.csproj
+          dotnet restore src/Taxjar/Taxjar.csproj
+          msbuild src/Taxjar/Taxjar.csproj /p:configuration=Release
+          cp src/Taxjar/bin/Release/netstandard2.0/TaxJar.dll build/netstandard2.0
+      - name: Build release DLL for .NET 4.5.2
+        run: |
+          sed -i 's/^\(\s*\)<TargetFrameworks>.*$/\1<TargetFrameworks>net452<\/TargetFrameworks>/' src/Taxjar/Taxjar.csproj
+          dotnet restore src/Taxjar/Taxjar.csproj
+          msbuild src/Taxjar/Taxjar.csproj /p:configuration=Release /p:targetframework=net452
+          cp src/Taxjar/bin/Release/net452/TaxJar.dll build/net452
+      - name: Create NuGet package
+        run: |
+          sed -i 's/^\(\s*\)<TargetFrameworks>.*$/\1<TargetFrameworks>netstandard2.0;net452<\/TargetFrameworks>/' src/Taxjar/Taxjar.csproj
+          mono build/nuget.exe pack build/TaxJar.nuspec
+      - name: Publish NuGet package
+        run: mono build/nuget.exe push TaxJar.$TAXJAR_VERSION.nupkg ${{ secrets.NUGET_API_TOKEN }} -Source https://www.nuget.org/api/v2/package


### PR DESCRIPTION
This PR sets up a [GitHub Actions](https://github.com/features/actions) workflow for releasing new versions of taxjar.net to [NuGet](https://www.nuget.org/).

The workflow automates the manual release procedures documented [here](https://taxjar.atlassian.net/wiki/spaces/PI/pages/741605399/C+.NET+API+Client). Going forward, new NuGet packages will be published simply by pushing a tag to GitHub. This should save time on future releases and make the process less prone to human error.