### PR TITLE
Bug/int 1329 async method params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ TaxJar.dll
 Taxjar.userprefs
 
 .env
+secrets.json

--- a/README.md
+++ b/README.md
@@ -941,10 +941,12 @@ catch(TaxjarException e)
 
 ## Tests
 
-We use [NUnit](https://github.com/nunit/nunit) and [WireMock.Net](https://github.com/WireMock-Net/WireMock.Net) for testing. Before running the specs, create a `.env` file inside the `Taxjar.Tests` directory with your sandbox API key:
+We use [NUnit](https://github.com/nunit/nunit) and [WireMock.Net](https://github.com/WireMock-Net/WireMock.Net) for testing. Before running the specs, create a `secrets.json` file inside the `Taxjar.Tests` directory with your sandbox API Token:
 
 ```
-TAXJAR_API_KEY=YOUR_TAXJAR_SANDBOX_API_KEY
+{
+  "ApiToken": "YOUR_SANDBOX_KEY"
+}
 ```
 
 ## More Information

--- a/src/Taxjar.Tests/Bootstrap.cs
+++ b/src/Taxjar.Tests/Bootstrap.cs
@@ -1,8 +1,8 @@
-﻿using NUnit.Framework;
+using System.IO;
+using Newtonsoft.Json;
+using NUnit.Framework;
 using WireMock.Server;
 using WireMock.Settings;
-using WireMock.RequestBuilders;
-using WireMock.ResponseBuilders;
 
 namespace Taxjar.Tests
 {
@@ -16,8 +16,6 @@ namespace Taxjar.Tests
         [OneTimeSetUp]
         public static void Init()
         {
-            DotNetEnv.Env.Load("../../../.env");
-
             if (server == null)
             {
                 server = FluentMockServer.Start(new FluentMockServerSettings
@@ -26,7 +24,8 @@ namespace Taxjar.Tests
                 });
             }
 
-            apiKey = System.Environment.GetEnvironmentVariable("TAXJAR_API_KEY") ?? "foo123";
+            var options = GetTestOptions();
+            apiKey = options.ApiToken;
             client = new TaxjarApi(apiKey, new { apiUrl = "http://localhost:9191" });
         }
 
@@ -34,6 +33,18 @@ namespace Taxjar.Tests
         public static void Destroy()
         {
             server.Stop();
+        }
+
+        private static TestOptions GetTestOptions()
+        {
+            var json = File.ReadAllText("../../../secrets.json");
+            var options = JsonConvert.DeserializeObject<TestOptions>(json);
+            return options;
+        }
+
+        private class TestOptions
+        {
+            public string ApiToken { get; set; }
         }
     }
 }

--- a/src/Taxjar.Tests/Customers.cs
+++ b/src/Taxjar.Tests/Customers.cs
@@ -312,7 +312,7 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-            var systemException = Assert.Throws<Exception>(() => Bootstrap.client.UpdateCustomer(new
+            var systemException = Assert.Throws<ArgumentException>(() => Bootstrap.client.UpdateCustomer(new
             {
                 exemption_type = "wholesale",
                 name = "Sterling Cooper",

--- a/src/Taxjar.Tests/Customers.cs
+++ b/src/Taxjar.Tests/Customers.cs
@@ -1,8 +1,9 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using Taxjar.Infrastructure;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 
@@ -253,6 +254,7 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
+            // verify customer_id
             var customer = await Bootstrap.client.UpdateCustomerAsync(new
             {
                 customer_id = "123",
@@ -262,6 +264,27 @@ namespace Taxjar.Tests
                     new {
                       country = "US",
                       state = "NY"
+                    }
+                },
+                country = "US",
+                state = "NY",
+                zip = "10010",
+                city = "New York",
+                street = "405 Madison Ave"
+            });
+
+            AssertCustomer(customer);
+
+            // verify CustomerId
+            customer = await Bootstrap.client.UpdateCustomerAsync(new
+            {
+                CustomerId = "123",
+                exemption_type = "wholesale",
+                name = "Sterling Cooper",
+                exempt_regions = new[] {
+                    new {
+                        country = "US",
+                        state = "NY"
                     }
                 },
                 country = "US",
@@ -306,7 +329,7 @@ namespace Taxjar.Tests
                 street = "405 Madison Ave"
             }));
 
-            Assert.AreEqual("Missing customer ID for `UpdateCustomer`", systemException.Message);
+            Assert.AreEqual(ErrorMessage.MissingCustomerId, systemException.Message);
         }
 
         [Test]

--- a/src/Taxjar.Tests/TaxJar.Tests.csproj
+++ b/src/Taxjar.Tests/TaxJar.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
@@ -26,7 +26,6 @@
     <PackageReference Include="RestSharp" Version="106.10.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="WireMock.Net.StandAlone" Version="1.0.19.0" />
-    <PackageReference Include="DotNetEnv" Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Taxjar.Tests/Transactions.cs
+++ b/src/Taxjar.Tests/Transactions.cs
@@ -1,8 +1,9 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using Taxjar.Infrastructure;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 
@@ -330,9 +331,32 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
+            // verify transaction_id
             var order = await Bootstrap.client.UpdateOrderAsync(new
             {
                 transaction_id = "123",
+                amount = 17.95,
+                shipping = 2,
+                exemption_type = "non_exempt",
+                line_items = new[] {
+                    new {
+                        quantity = 1,
+                        product_identifier = "12-34243-0",
+                        description = "Heavy Widget",
+                        product_tax_code = "20010",
+                        unit_price = 15,
+                        discount = 0,
+                        sales_tax = 0.95
+                    }
+                }
+            });
+
+            AssertOrder(order);
+
+            // verify TransactionId
+            order = await Bootstrap.client.UpdateOrderAsync(new
+            {
+                TransactionId = "123",
                 amount = 17.95,
                 shipping = 2,
                 exemption_type = "non_exempt",
@@ -367,7 +391,7 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-            var systemException = Assert.Throws<Exception>(() => Bootstrap.client.UpdateOrder(new
+            var systemException = Assert.Throws<ArgumentException>(() => Bootstrap.client.UpdateOrder(new
             {
                 amount = 17.95,
                 shipping = 2,
@@ -385,7 +409,7 @@ namespace Taxjar.Tests
                 }
             }));
 
-            Assert.AreEqual("Missing transaction ID for `UpdateOrder`", systemException.Message);
+            Assert.AreEqual(ErrorMessage.MissingTransactionId, systemException.Message);
         }
 
         [Test]
@@ -711,7 +735,7 @@ namespace Taxjar.Tests
                     .WithBodyAsJson(body)
             );
 
-            var systemException = Assert.Throws<Exception>(() => Bootstrap.client.UpdateRefund(new
+            var systemException = Assert.Throws<ArgumentException>(() => Bootstrap.client.UpdateRefund(new
             {
                 amount = 17.95,
                 shipping = 2,
@@ -729,7 +753,7 @@ namespace Taxjar.Tests
                 }
             }));
 
-            Assert.AreEqual("Missing transaction ID for `UpdateRefund`", systemException.Message);
+            Assert.AreEqual(ErrorMessage.MissingTransactionId, systemException.Message);
         }
 
         [Test]

--- a/src/Taxjar/Infrastructure/ErrorMessage.cs
+++ b/src/Taxjar/Infrastructure/ErrorMessage.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+[assembly: InternalsVisibleTo("TaxJar.Tests")]
+
+namespace Taxjar.Infrastructure
+{
+    internal static class ErrorMessage
+    {
+        public const string MissingTransactionId = "Transaction ID cannot be null or an empty string.";
+        public const string MissingCustomerId = "Customer ID cannot be null or an empty string.";
+    }
+}

--- a/src/Taxjar/Taxjar.csproj
+++ b/src/Taxjar/Taxjar.csproj
@@ -22,7 +22,6 @@
 
   <ItemGroup>
     <Folder Include="Entities\" />
-    <Folder Include="Infrastructure\" />
     <Folder Include="Properties\" />
   </ItemGroup>
 

--- a/src/Taxjar/Taxjar.csproj
+++ b/src/Taxjar/Taxjar.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <Folder Include="Entities\" />
+    <Folder Include="Infrastructure\" />
     <Folder Include="Properties\" />
   </ItemGroup>
 

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -480,7 +480,7 @@ namespace Taxjar
             var customerId = GetValueOrDefault(parameters, propertyInfo);
             if (string.IsNullOrWhiteSpace(customerId))
             {
-                throw new Exception(ErrorMessage.MissingCustomerId);
+                throw new ArgumentException(ErrorMessage.MissingCustomerId);
             }
 
             return customerId;

--- a/src/Taxjar/TaxjarApi.cs
+++ b/src/Taxjar/TaxjarApi.cs
@@ -462,7 +462,6 @@ namespace Taxjar
         private string GetTransactionIdFromParameters(object parameters)
         {
             var propertyInfo = parameters.GetType().GetProperty("transaction_id") ?? parameters.GetType().GetProperty("TransactionId");
-
             var transactionId = GetValueOrDefault(parameters, propertyInfo);
 
             if (string.IsNullOrWhiteSpace(transactionId))
@@ -476,8 +475,8 @@ namespace Taxjar
         private string GetCustomerIdFromParameters(object parameters)
         {
             var propertyInfo = parameters.GetType().GetProperty("customer_id") ?? parameters.GetType().GetProperty("CustomerId");
-
             var customerId = GetValueOrDefault(parameters, propertyInfo);
+
             if (string.IsNullOrWhiteSpace(customerId))
             {
                 throw new ArgumentException(ErrorMessage.MissingCustomerId);


### PR DESCRIPTION
This pull request fixes issue #46:

- `TransactionId` and `CustomerId` are now valid parameters for the `async` methods. 
- The exception message has been slightly reworded for consistency.
- An `ArgumentException` is now thrown over the [base Exception](https://docs.microsoft.com/en-us/dotnet/csharp/programming-guide/exceptions/creating-and-throwing-exceptions#things-to-avoid-when-throwing-exceptions).
- The dependency on DotNetEnv has been removed in favor of the conventional `appsettings.json`.