### PR TITLE
Upgrades RestSharp to 106.12.0

### DIFF
--- a/build/TaxJar.nuspec
+++ b/build/TaxJar.nuspec
@@ -20,7 +20,7 @@
     <dependencies>
       <group>
         <dependency id="Newtonsoft.Json" version="12.0.3" />
-        <dependency id="RestSharp" version="[106.10.1,107.0.0)" />
+        <dependency id="RestSharp" version="106.12.0" />
       </group>
     </dependencies>
   </metadata>

--- a/build/TaxJar.nuspec
+++ b/build/TaxJar.nuspec
@@ -20,7 +20,7 @@
     <dependencies>
       <group>
         <dependency id="Newtonsoft.Json" version="12.0.3" />
-        <dependency id="RestSharp" version="106.12.0" />
+        <dependency id="RestSharp" version="[106.12.0,107.0.0)" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Taxjar.Tests/TaxJar.Tests.csproj
+++ b/src/Taxjar.Tests/TaxJar.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="RestSharp" Version="106.10.1" />
+    <PackageReference Include="RestSharp" Version="106.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="WireMock.Net.StandAlone" Version="1.0.19.0" />
   </ItemGroup>

--- a/src/Taxjar/Taxjar.csproj
+++ b/src/Taxjar/Taxjar.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.10.1" />
+    <PackageReference Include="RestSharp" Version="106.12.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
[There's a ReDoS vulnerability found](https://snyk.io/vuln/SNYK-DOTNET-RESTSHARP-1316436) in our version of RestSharp.

It is recommended to upgrade to version `106.11.8-alpha.0.13` or higher.